### PR TITLE
Remove in project secrets class

### DIFF
--- a/Mobile.BuildTools/Generators/SecretsClassGenerator.cs
+++ b/Mobile.BuildTools/Generators/SecretsClassGenerator.cs
@@ -73,19 +73,15 @@ namespace Mobile.BuildTools.Generators
             var secretsClass = GenerateClass(replacement);
             Log.LogMessage((bool)DebugOutput ? secretsClass : GenerateClass(Regex.Replace(safeReplacement, "\n\n$", "")));
 
-            if (!Directory.Exists(OutputPath))
-            {
-                Directory.CreateDirectory(OutputPath);
-            }
-
-            var outputFile = Path.Combine(OutputPath, $"{SecretsClassName}.cs");
+            var projectFile = Path.Combine(OutputPath, $"{SecretsClassName}.cs");
             var intermediateFile = Path.Combine(IntermediateOutputPath, $"{SecretsClassName}.cs");
+            var outputFile = File.Exists(projectFile) ? projectFile : intermediateFile;
             Log.LogMessage($"Writing Secrets Class to: '{outputFile}'");
-            GeneratedFiles = File.Exists(outputFile) ? new ITaskItem[0] : new ITaskItem[] {
+            GeneratedFiles = new ITaskItem[] {
                 new TaskItem(ProjectCollection.Escape(outputFile))
             };
+
             File.WriteAllText(outputFile, secretsClass);
-            File.WriteAllText(intermediateFile, secretsClass);
         }
 
         internal string GenerateClass(string replacement) =>

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -21,6 +21,10 @@ If these projects have helped you reduce time to develop and made your app bette
 
 [![paypal](https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif)](https://www.paypal.me/dansiegel)
 
+## Samples
+
+- [AppCenter.DemoApp](https://github.com/dansiegel/AppCenter.DemoApp) - Sample Xamarin Forms app that protects the Info.plist &amp; AndroidManifest.xml, injects the AppCenter App Secrets, and automatically increments the app version on each build using timestamps locally and the Build Id when on built AppCenter.
+
 ## Prism MFractor Config
 
 As part of the DevOps tooling, you can now easily include an MFractor config to enable MFractor to better utilize Prism naming conventions. If you have modified your project structure you can always override individual settings by adding your own MFractor config. More information can be found in the [MFractor Docs](http://docs.mfractor.com/). Configurations are available both for generic Prism applications and those using the Prism QuickStart Templates.
@@ -88,6 +92,10 @@ namespace YourApp.Helpers
     }
 }
 ```
+
+#### v1.1 and beyond
+
+Starting in v1.1 a new behavior has been introduced for the Secrets task. By default the Secrets class will be generated in the Intermediate Output Folder (`{ProjectPath}\obj\Secrets.cs`) rather than in the project itself (`{ProjectPath}\Helpers\Secrets.cs`). Since standard .gitignore files already ignore this folder you will only need to add an ignore for the secrets.json file. If you prefer to see the generated class and don't mind having the file ignored, all you need to do is create a file in the standard output path as shown above and it will update that file instead. When updating from 1.0, you will not automatically see any changes because you already have the Secrets.cs in your project. Deleting the file in your project will allow the Secrets task to change to the new behavior.
 
 ### Build Host Secrets
 


### PR DESCRIPTION
# Description 

The existing behavior for the Secrets task has added the need to exclude two files from source control.  This is good in the sense that it lessens the feeling of "Magic" since the generated code file is fully visible inside the project. This however also makes it more likely that values could be exposed to source control. 

## Behavior Changes

The secrets class will now prefer to be generated in the Intermediate Output Folder (obj folder). This reduces the likelihood of the generated class being included in source control, and minimizes the change to the ignore file to only ignore secrets.json. 

If the Secrets.cs exists in the project path it will continue to update the in-project file. This provides backwards compatibility and ensures that it is easy for developers to not feel like there is "too much magic".