### PR TITLE
fix capitalized boolean output

### DIFF
--- a/Mobile.BuildTools/Generators/SecretsClassGenerator.cs
+++ b/Mobile.BuildTools/Generators/SecretsClassGenerator.cs
@@ -93,7 +93,7 @@ namespace Mobile.BuildTools.Generators
             var outputValue = safeOutput ? SafePlaceholder : value;
             if (bool.TryParse(value, out bool b))
             {
-                return $"{TabSpace}{TabSpace}internal const bool {secret.Key} = {outputValue};\n\n";
+                return $"{TabSpace}{TabSpace}internal const bool {secret.Key} = {outputValue.ToLower()};\n\n";
             }
             else if (double.TryParse(value, out double d))
             {


### PR DESCRIPTION
# Description

Newtonsoft capitalizes booleans in the JToken. This results in a build error when injecting boolean values with the Secrets generator.

## Bugs fixed

Booleans outputs now call ToLower to ensure proper code generation