### PR TITLE
Outputs copy

### DIFF
--- a/Mobile.BuildTools/build/Mobile.BuildTools.props
+++ b/Mobile.BuildTools/build/Mobile.BuildTools.props
@@ -16,6 +16,18 @@
     <IsMacOSProject>false</IsMacOSProject>
     <IsTizenProject>false</IsTizenProject>
     <MobileBuildToolsTargets>$(MSBuildThisFileDirectory)Mobile.BuildTools.targets</MobileBuildToolsTargets>
+    <BuildToolsArtifactOutputPath>$([System.IO.Path]::Combine('$(SolutionDir)', 'Artifacts'))</BuildToolsArtifactOutputPath>
+    <BuildToolsArtifactOutputPath Condition=" '$(BUILD_ARTIFACTSTAGINGDIRECTORY)' != '' ">$(BUILD_ARTIFACTSTAGINGDIRECTORY)</BuildToolsArtifactOutputPath>
+    <IsAppCenter Condition=" '$(IsAppCenter)' == '' ">false</IsAppCenter>
+    <IsAppCenter Condition=" '$(APPCENTER_BUILD_ID)' != '' ">true</IsAppCenter>
+    <IsVSTS Condition=" '$(IsVSTS)' == '' ">false</IsVSTS>
+    <IsVSTS Condition=" '$(BUILD_BUILDNUMBER)' != '' ">true</IsVSTS>
+    <IsAppVeyor Condition=" '$(IsAppVeyor)' == '' ">false</IsAppVeyor>
+    <IsAppVeyor Condition=" '$(APPVEYOR_BUILD_NUMBER)' != '' ">true</IsAppVeyor>
+    <IsJenkins Condition=" '$(IsJenkins)' == '' ">false</IsJenkins>
+    <IsJenkins Condition=" '$(BUILD_NUMBER)' != '' ">true</IsJenkins>
+    <IsBuildHost Condition=" '$(IsBuildHost)' == '' ">false</IsBuildHost>
+    <IsBuildHost Condition=" '$(IsAppCenter)' Or '$(IsVSTS)' Or '$(IsAppVeyor)' Or '$(IsJenkins)' ">true</IsBuildHost>
   </PropertyGroup>
 
   <Choose>

--- a/Mobile.BuildTools/build/Mobile.BuildTools.props
+++ b/Mobile.BuildTools/build/Mobile.BuildTools.props
@@ -16,7 +16,7 @@
     <IsMacOSProject>false</IsMacOSProject>
     <IsTizenProject>false</IsTizenProject>
     <MobileBuildToolsTargets>$(MSBuildThisFileDirectory)Mobile.BuildTools.targets</MobileBuildToolsTargets>
-    <BuildToolsArtifactOutputPath>$([System.IO.Path]::Combine('$(SolutionDir)', 'Artifacts'))</BuildToolsArtifactOutputPath>
+    <BuildToolsArtifactOutputPath Condition=" '$(BuildToolsArtifactOutputPath)' == '' ">$([System.IO.Path]::Combine('$(SolutionDir)', 'Artifacts'))</BuildToolsArtifactOutputPath>
     <BuildToolsArtifactOutputPath Condition=" '$(BUILD_ARTIFACTSTAGINGDIRECTORY)' != '' ">$(BUILD_ARTIFACTSTAGINGDIRECTORY)</BuildToolsArtifactOutputPath>
     <IsAppCenter Condition=" '$(IsAppCenter)' == '' ">false</IsAppCenter>
     <IsAppCenter Condition=" '$(APPCENTER_BUILD_ID)' != '' ">true</IsAppCenter>

--- a/Mobile.BuildTools/build/Mobile.BuildTools.targets
+++ b/Mobile.BuildTools/build/Mobile.BuildTools.targets
@@ -8,6 +8,8 @@
              AssemblyFile="$(MSBuildThisFileDirectory)Mobile.BuildTools.dll"/>
   <UsingTask TaskName="Mobile.BuildTools.Tasks.AutomaticBuildVersioningTask"
              AssemblyFile="$(MSBuildThisFileDirectory)Mobile.BuildTools.dll"/>
+  <UsingTask TaskName="Mobile.BuildTools.Tasks.CopyAppOutputsTask"
+             AssemblyFile="$(MSBuildThisFileDirectory)Mobile.BuildTools.dll"/>
 
   <Target Name="TemplateManifest" 
           BeforeTargets="CoreCompile;_CoreXamlG;XamlG;XamlC;Build;_CleanMsymArchive;_CleanAppBundle;PrepareForBuild;_CoreCompileInterfaceDefinitions;_SetLatestTargetFrameworkVersion">
@@ -92,6 +94,45 @@
                                   TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
                                   SdkShortFrameworkIdentifier="$(_SdkShortFrameworkIdentifier)"
                                   DebugOutput="$(MobileBuildToolsDebug)" />
+  </Target>
+
+  <Target Name="IPACopyToStagingDirectory"
+          AfterTargets="_ZipIpa"
+          DependsOnTargets="_ZipIpa"
+          Condition=" '$(DisableBuildToolsArtifactCopy)' != 'false' And !'$(IsAppCenter)' ">
+
+    <PropertyGroup>
+      <__IpaFileName>$([System.IO.Path]::GetFileNameWithoutExtension('$(IpaPackagePath)'))</__IpaFileName>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <__Generated_dSYM Include="$([System.IO.Path]::GetDirectoryName('$(IpaPackagePath)'))\**" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(__Generated_dSYM)" 
+          DestinationFolder="$(BuildToolsArtifactOutputPath)\$(__IpaFileName).app.dSYM\%(RecursiveDir)" 
+          SkipUnchangedFiles="false" 
+          OverwriteReadOnlyFiles="true" 
+          Retries="3" 
+          RetryDelayMilliseconds="300" />
+
+    <Copy SourceFiles="$(IpaPackagePath)" 
+          DestinationFiles="$(BuildToolsArtifactOutputPath)\$([System.IO.Path]::GetFileName('$(IpaPackagePath)'))" />
+
+  </Target>
+
+  <Target Name="APKCopyToStagingDirectory"
+          AfterTargets="_CreateBaseApk"
+          DependsOnTargets="_CreateBaseApk"
+          Condition=" '$(DisableBuildToolsArtifactCopy)' != 'false' And !'$(IsAppCenter)' ">
+    
+    <ItemGroup>
+      <__Generated_APK Include="$(OutputPath)\**\*.apk" />
+    </ItemGroup>
+
+    <Copy SourceFiles="$(__Generated_APK)" 
+          DestinationFiles="$(BuildToolsArtifactOutputPath)\%(Filename)%(Extension)" />
+
   </Target>
 
 </Project>

--- a/Mobile.BuildTools/build/Mobile.BuildTools.targets
+++ b/Mobile.BuildTools/build/Mobile.BuildTools.targets
@@ -8,8 +8,6 @@
              AssemblyFile="$(MSBuildThisFileDirectory)Mobile.BuildTools.dll"/>
   <UsingTask TaskName="Mobile.BuildTools.Tasks.AutomaticBuildVersioningTask"
              AssemblyFile="$(MSBuildThisFileDirectory)Mobile.BuildTools.dll"/>
-  <UsingTask TaskName="Mobile.BuildTools.Tasks.CopyAppOutputsTask"
-             AssemblyFile="$(MSBuildThisFileDirectory)Mobile.BuildTools.dll"/>
 
   <Target Name="TemplateManifest" 
           BeforeTargets="CoreCompile;_CoreXamlG;XamlG;XamlC;Build;_CleanMsymArchive;_CleanAppBundle;PrepareForBuild;_CoreCompileInterfaceDefinitions;_SetLatestTargetFrameworkVersion">

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -51,6 +51,11 @@ As part of the Build Tools, a number of Build Properties are added to better ass
 - IsUWPProject
 - IsMacOSProject
 - IsTizenProject
+- IsAppCenter
+- IsAppVeyor
+- IsJenkins
+- IsVSTS
+- IsBuildHost
 
 **Notes:**
 
@@ -227,6 +232,15 @@ To enable Automatic Versioning you will need to open your iOS or Android project
   <AutomaticVersionBehavior>PreferBuildNumber</AutomaticVersionBehavior>
 </PropertyGroup>
 ```
+
+### App Package (Artifacts) Copy
+
+It can sometimes be confusing as to where you generated App Package is after you build. Mobile.BuildTools helps you with this by automatically copying the generated APK, IPA and dSYM to an artifacts folder under the solution directory. It does this with some intelligence by disabling the copy on AppCenter since there is no need, and it will copy to `Build.ArtifactStagingDirectory` allowing you to more easily discover and consume the outputs when built on VSTS.
+
+| Property | Default |
+| -------- | ------- |
+| BuildToolsArtifactOutputPath | `{Solution Dir}/Artifacts` |
+| DisableBuildToolsArtifactCopy | `false` |
 
 [PrismNuGetShield]: https://img.shields.io/nuget/vpre/Prism.MFractor.Config.svg
 [QuickStartNuGetShield]: https://img.shields.io/nuget/vpre/Prism.QuickStart.MFractor.Config.svg


### PR DESCRIPTION
# Description

Adds enhancement from issue #11. Generated APK, IPA, and dSYM are now copied to the Artifacts directory under the `$(SolutionDir)`, and in `$(Build.ArtifactStagingDirectory)` on VSTS.

## Changes

### New Default Properties Introduced

- IsAppCenter
- IsAppVeyor
- IsJenkins
- IsVSTS
- IsBuildHost

### Task Specific Properties

- BuildToolsArtifactOutputPath - this can be used to override the default path locally but not on VSTS
- DisableBuildToolsArtifactCopy - setting this to true will disable this copy tasks