### PR TITLE
Fix custom Namespaces

### DIFF
--- a/Mobile.BuildTools.Tests/Fixtures/SecretsClassGeneratorFixture.cs
+++ b/Mobile.BuildTools.Tests/Fixtures/SecretsClassGeneratorFixture.cs
@@ -83,5 +83,21 @@ namespace Mobile.BuildTools.Tests.Fixtures
             var output = generator.ProcessSecret(pair);
             Assert.Contains($"const string {key}", output);
         }
+
+        [Fact]
+        public void GeneratesCorrectNamespace_WithSpecifiedBaseNamespace()
+        {
+            var generator = GetGenerator();
+            generator.BaseNamespace = "Foo.Bar";
+            generator.OutputPath = "/Repos/AwesomeProject/Foo/Helpers";
+            generator.ProjectBasePath = "/Repos/AwesomeProject/Foo";
+
+
+            string @namespace = null;
+            var exception = Record.Exception(() => @namespace = generator.GetNamespace());
+            Assert.Null(exception);
+
+            Assert.Equal("Foo.Bar.Helpers", @namespace);
+        }
     }
 }

--- a/Mobile.BuildTools/Generators/SecretsClassGenerator.cs
+++ b/Mobile.BuildTools/Generators/SecretsClassGenerator.cs
@@ -109,7 +109,7 @@ namespace Mobile.BuildTools.Generators
             }
         }
 
-        private string GetNamespace()
+        internal string GetNamespace()
         {
             Uri file = new Uri(OutputPath);
             // Must end in a slash to indicate folder
@@ -120,6 +120,16 @@ namespace Mobile.BuildTools.Generators
                     .ToString()
                     .Replace('/', '.')
                 );
+
+            if(!string.IsNullOrWhiteSpace(BaseNamespace))
+            {
+                var folderName = Path.GetFileName(ProjectBasePath);
+                relativePath = Regex.Replace(relativePath, folderName, BaseNamespace);
+            }
+            else
+            {
+                Log.LogWarning($"Using Fallback namespace: {relativePath}");
+            }
 
             return relativePath;
         }


### PR DESCRIPTION
Fixes #30 
Ensures that when the Project Folder Name is different from the Root Namespace that the Root Namespace will be used. Logs warning if the Root Namespace is null/empty.