### PR TITLE
Add terminating semicolon during minify

### DIFF
--- a/Mobile.BuildTools.Tests/Templates/Css/style.min.css
+++ b/Mobile.BuildTools.Tests/Templates/Css/style.min.css
@@ -1,1 +1,1 @@
-body{font:100% Helvetica,sans-serif;color:#333}
+body{font:100% Helvetica,sans-serif;color:#333;}

--- a/Mobile.BuildTools.Tests/Templates/Css/style2.min.css
+++ b/Mobile.BuildTools.Tests/Templates/Css/style2.min.css
@@ -1,1 +1,1 @@
-^contentpage{background-color:#333;padding:20px}^button{border-radius:10px}
+^contentpage{background-color:#333;padding:20px;}^button{border-radius:10px;}

--- a/Mobile.BuildTools/Tasks/ScssProcessorTask.cs
+++ b/Mobile.BuildTools/Tasks/ScssProcessorTask.cs
@@ -76,7 +76,8 @@ namespace Mobile.BuildTools.Tasks
                     Logger.LogMessage($"minifying output to '{outputFile}'");
                     CssSettings settings = new CssSettings
                     {
-                        CommentMode = CssComment.None
+                        CommentMode = CssComment.None,
+                        TermSemicolons = true,
                     };
 
                     UglifyResult uglifyResult = Uglify.Css(result.Css, settings);


### PR DESCRIPTION
Looks like Xamarin is expecting all CSS declarations to end with a semicolon. Was having trouble with the last value from a .scss not being applied after Uglify created the CSS. 

Added TermSemicolons option to CssSettings.