### PR TITLE
The package path must be an actual relative file name

### DIFF
--- a/Directory.build.props
+++ b/Directory.build.props
@@ -20,6 +20,6 @@
   </PropertyGroup>
 
   <ItemGroup Condition="$(IsPackable)">
-    <None Include="$(MSBuildThisFileDirectory)logo\icon.png" Pack="true" PackagePath="\" />
+    <None Include="$(MSBuildThisFileDirectory)logo\icon.png" Pack="true" PackagePath="\icon.png" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This was causing the pack to fail.