### PR TITLE
[Enhancement] Add Default Environment variables to buildtools.json

### DIFF
--- a/docs/schemas/v2/buildtools.schema.json
+++ b/docs/schemas/v2/buildtools.schema.json
@@ -73,6 +73,28 @@
         }
       }
     },
+    "EnvironmentSettings": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "default": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "default": { }
+        },
+        "configuration": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "default": { "Debug": { } }
+        }
+      }
+    },
     "ImageResize": {
       "type": [
         "object",
@@ -354,6 +376,9 @@
         "$ref": "#/definitions/SecretsConfig"
       }
     },
+    "environment": {
+      "type": [ "object", "null" ]
+    }
     "debug": {
       "type": "boolean"
     }

--- a/samples/BuildToolsSample/buildtools.json
+++ b/samples/BuildToolsSample/buildtools.json
@@ -71,5 +71,15 @@
       ]
     }
   },
+  "environment": {
+    "defaults": {
+      "AppId": "com.avantipoint.buildtoolssample"
+    },
+    "configuration": {
+      "Debug": {
+        "AppId": "com.avantipoint.buildtoolssampledev"
+      }
+    }
+  },
   "debug": true
 }

--- a/samples/BuildToolsSample/src/platform/BuildToolsSample.Android/Properties/AndroidManifest.xml
+++ b/samples/BuildToolsSample/src/platform/BuildToolsSample.Android/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.avantipoint.buildtoolssample">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="$AppId$">
 	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="29" />
 	<application android:label="$AppDisplayName$"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/samples/BuildToolsSample/src/platform/BuildToolsSample.iOS/Info.plist
+++ b/samples/BuildToolsSample/src/platform/BuildToolsSample.iOS/Info.plist
@@ -25,7 +25,7 @@
 	<key>CFBundleDisplayName</key>
 	<string>$AppDisplayName$</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.avantipoint.buildtoolssample</string>
+	<string>com.company.placeholder</string>
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
 	<key>UILaunchStoryboardName</key>

--- a/src/Mobile.BuildTools/AndroidManifest.targets
+++ b/src/Mobile.BuildTools/AndroidManifest.targets
@@ -23,6 +23,8 @@
       <TemplateAppManifest>$(IntermediateOutputPath)android\AndroidManifest.xml</TemplateAppManifest>
       <ProcessedAppManifest>$([System.IO.Path]::Combine('$(IntermediateOutputPath)', 'templated', 'AndroidManifest.xml'))</ProcessedAppManifest>
       <VersionedAppManifest>$([System.IO.Path]::Combine('$(IntermediateOutputPath)', 'versioned', 'AndroidManifest.xml'))</VersionedAppManifest>
+      <InputAndroidManifest>$(AndroidManifest)</InputAndroidManifest>
+      <AndroidManifest>$(ProcessedAppManifest)</AndroidManifest>
     </PropertyGroup>
 
     <ItemGroup>
@@ -43,11 +45,9 @@
                           IntermediateOutputPath="$(IntermediateOutputPath)"
                           TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
                           ReferenceAssemblyPaths="$(_XATargetFrameworkDirectories)"
-                          ManifestPath="$(TemplateAppManifest)"
-                          Condition="$(BuildToolsEnableTemplateManifests)">
-      <Output TaskParameter="ProcessedManifest"
-              PropertyName="_AppManifest" />
-    </TemplateManifestTask>
+                          ManifestPath="$(InputAndroidManifest)"
+                          OutputManifestPath="$(ProcessedAppManifest)"
+                          Condition="$(BuildToolsEnableTemplateManifests)" />
   </Target>
 
   <Target Name="AutomaticBuildVersioning"
@@ -61,12 +61,10 @@
                                   Configuration="$(Configuration)"
                                   IntermediateOutputPath="$(IntermediateOutputPath)"
                                   TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
-                                  ManifestPath="$(TemplateAppManifest)"
+                                  ManifestPath="$(ProcessedAppManifest)"
+                                  OutputManifestPath="$(ProcessedAppManifest)"
                                   ReferenceAssemblyPaths="$(_XATargetFrameworkDirectories)"
-                                  Condition="$(BuildToolsEnableAutomaticVersioning)" >
-      <!--<Output TaskParameter="VersionedManifest"
-              PropertyName="_AppManifest" />-->
-    </AutomaticBuildVersioningTask>
+                                  Condition="$(BuildToolsEnableAutomaticVersioning)" />
   </Target>
 
 </Project>

--- a/src/Mobile.BuildTools/Constants.cs
+++ b/src/Mobile.BuildTools/Constants.cs
@@ -15,5 +15,7 @@
         public const string DefaultBackgroundColor = "#FFFFFF";
 
         public const double DefaultOpacity = 0.95;
+
+        public const string AppPackageName = "MBTPackageName";
     }
 }

--- a/src/Mobile.BuildTools/Generators/Manifests/DefaultTemplatedManifestGenerator.cs
+++ b/src/Mobile.BuildTools/Generators/Manifests/DefaultTemplatedManifestGenerator.cs
@@ -13,5 +13,12 @@ namespace Mobile.BuildTools.Generators.Manifests
         protected override string ReadManifest() => File.ReadAllText(ManifestOutputPath);
 
         protected override void SaveManifest(string manifest) => File.WriteAllText(ManifestOutputPath, manifest);
+
+        protected override string SetAppBundleId(string manifest, string packageName)
+        {
+            // Not Implemented
+            Log.LogWarning($"An app bundle id '{packageName}' has been provided, but this may not be supported on this platform ({Build.Platform}).");
+            return manifest;
+        }
     }
 }

--- a/src/Mobile.BuildTools/Generators/Manifests/TemplatedAndroidAppManifestGenerator.cs
+++ b/src/Mobile.BuildTools/Generators/Manifests/TemplatedAndroidAppManifestGenerator.cs
@@ -24,5 +24,12 @@ namespace Mobile.BuildTools.Generators.Manifests
             var doc = XDocument.Parse(manifest);
             AndroidAppManifest.Load(doc, AndroidVersions).WriteToFile(ManifestOutputPath);
         }
+
+        protected override string SetAppBundleId(string manifest, string packageName)
+        {
+            var appManifest = AndroidAppManifest.Load(XDocument.Parse(manifest), AndroidVersions);
+            appManifest.PackageName = packageName;
+            return appManifest.Document.ToString();
+        }
     }
 }

--- a/src/Mobile.BuildTools/Generators/Manifests/TemplatedPlistGenerator.cs
+++ b/src/Mobile.BuildTools/Generators/Manifests/TemplatedPlistGenerator.cs
@@ -16,7 +16,14 @@ namespace Mobile.BuildTools.Generators.Manifests
         protected override void SaveManifest(string manifest)
         {
             var plist = PDictionary.FromString(manifest);
-            File.WriteAllBytes(ManifestOutputPath, plist.ToByteArray(PropertyListFormat.Binary));
+            File.WriteAllBytes(ManifestOutputPath, plist.ToByteArray(PropertyListFormat.Xml));
+        }
+
+        protected override string SetAppBundleId(string manifest, string packageName)
+        {
+            var plist = PDictionary.FromString(manifest) as PDictionary;
+            plist.SetCFBundleIdentifier(packageName);
+            return plist.ToXml();
         }
     }
 }

--- a/src/Mobile.BuildTools/Generators/Secrets/BuildHostSecretsGenerator.cs
+++ b/src/Mobile.BuildTools/Generators/Secrets/BuildHostSecretsGenerator.cs
@@ -77,6 +77,6 @@ namespace Mobile.BuildTools.Generators.Secrets
         }
 
         internal IDictionary<string, string> GetSecrets(string knownPrefix) =>
-            Utils.EnvironmentAnalyzer.GetSecrets(Build.Platform, knownPrefix);
+            Utils.EnvironmentAnalyzer.GetSecrets(Build, knownPrefix);
     }
 }

--- a/src/Mobile.BuildTools/Generators/Secrets/SecretsClassGenerator.cs
+++ b/src/Mobile.BuildTools/Generators/Secrets/SecretsClassGenerator.cs
@@ -151,7 +151,27 @@ namespace Mobile.BuildTools.Generators.Secrets
                 throw new Exception("An unexpected error occurred. Could not locate any secrets.");
             }
 
+            if (Build?.Configuration?.Environment != null)
+            {
+                var settings = Build.Configuration.Environment;
+                UpdateVariables(settings.Defaults, ref secrets);
+                if (settings.Configuration != null && settings.Configuration.ContainsKey(Build.BuildConfiguration))
+                    UpdateVariables(settings.Configuration[Build.BuildConfiguration], ref secrets);
+            }
+
             return secrets;
+        }
+
+        private static void UpdateVariables(IDictionary<string, string> settings, ref JObject output)
+        {
+            if (settings is null)
+                return;
+
+            foreach ((var key, var value) in settings)
+            {
+                if (!output.ContainsKey(key))
+                    output[key] = value;
+            }
         }
 
         internal void CreateOrMerge(string jsonFilePath, ref JObject secrets)

--- a/src/Mobile.BuildTools/Generators/Versioning/AndroidAutomaticBuildVersionGenerator.cs
+++ b/src/Mobile.BuildTools/Generators/Versioning/AndroidAutomaticBuildVersionGenerator.cs
@@ -5,19 +5,19 @@ namespace Mobile.BuildTools.Generators.Versioning
 {
     internal class AndroidAutomaticBuildVersionGenerator : BuildVersionGeneratorBase
     {
-        public AndroidAutomaticBuildVersionGenerator(IBuildConfiguration buildConfiguration, string manifestPath)
-            : base(buildConfiguration, manifestPath)
+        public AndroidAutomaticBuildVersionGenerator(IBuildConfiguration buildConfiguration, string manifestPath, string outputPath)
+            : base(buildConfiguration, manifestPath, outputPath)
         {
         }
 
         public string[] ReferenceAssemblyPaths { get; set; }
 
-        protected override void ProcessManifest(string path, string buildNumber)
+        protected override void ProcessManifest(string path, string outputPath, string buildNumber)
         {
             var androidManifest = AndroidAppManifest.Load(path, new AndroidVersions(ReferenceAssemblyPaths));
             androidManifest.VersionCode = buildNumber;
             androidManifest.VersionName = $"{SanitizeVersion(androidManifest.VersionName)}.{buildNumber}";
-            androidManifest.WriteToFile(path);
+            androidManifest.WriteToFile(outputPath);
         }
     }
 }

--- a/src/Mobile.BuildTools/Generators/Versioning/BuildVersionGeneratorBase.cs
+++ b/src/Mobile.BuildTools/Generators/Versioning/BuildVersionGeneratorBase.cs
@@ -9,15 +9,17 @@ namespace Mobile.BuildTools.Generators.Versioning
 {
     internal abstract class BuildVersionGeneratorBase : GeneratorBase
     {
-        public BuildVersionGeneratorBase(IBuildConfiguration buildConfiguration, string manifestPath)
+        public BuildVersionGeneratorBase(IBuildConfiguration buildConfiguration, string manifestPath, string manifestOutputPath)
             : base(buildConfiguration)
         {
             ManifestPath = manifestPath;
+            ManifestOutputPath = string.IsNullOrEmpty(manifestOutputPath) ? manifestPath : manifestOutputPath;
         }
 
         private static DateTimeOffset EPOCOffset => new DateTimeOffset(new DateTime(2018, 1, 1));
 
         private string ManifestPath { get; }
+        private string ManifestOutputPath { get; }
         public VersionBehavior Behavior => Build.Configuration.AutomaticVersioning.Behavior;
         public VersionEnvironment VersionEnvironment => Build.Configuration.AutomaticVersioning.Environment;
         public int VersionOffset => Build.Configuration.AutomaticVersioning.VersionOffset;
@@ -50,7 +52,7 @@ namespace Mobile.BuildTools.Generators.Versioning
             LogManifestContents();
 
             Log.LogMessage("Processing Manifest");
-            ProcessManifest(ManifestPath, BuildNumber);
+            ProcessManifest(ManifestPath, ManifestOutputPath, BuildNumber);
 
             LogManifestContents();
         }
@@ -63,7 +65,7 @@ namespace Mobile.BuildTools.Generators.Versioning
             }
         }
 
-        protected abstract void ProcessManifest(string path, string buildNumber);
+        protected abstract void ProcessManifest(string path, string outputPath, string buildNumber);
 
         protected string GetBuildNumber()
         {

--- a/src/Mobile.BuildTools/Generators/Versioning/iOSAutomaticBuildVersionGenerator.cs
+++ b/src/Mobile.BuildTools/Generators/Versioning/iOSAutomaticBuildVersionGenerator.cs
@@ -6,18 +6,18 @@ namespace Mobile.BuildTools.Generators.Versioning
 {
     internal class iOSAutomaticBuildVersionGenerator : BuildVersionGeneratorBase
     {
-        public iOSAutomaticBuildVersionGenerator(IBuildConfiguration buildConfiguration, string manifestPath)
-            : base(buildConfiguration, manifestPath)
+        public iOSAutomaticBuildVersionGenerator(IBuildConfiguration buildConfiguration, string manifestPath, string outputPath)
+            : base(buildConfiguration, manifestPath, outputPath)
         {
         }
 
-        protected override void ProcessManifest(string plistPath, string buildNumber)
+        protected override void ProcessManifest(string plistPath, string outputPath, string buildNumber)
         {
             var infoPlist = PDictionary.FromFile(plistPath);
             infoPlist.SetCFBundleVersion(buildNumber);
             var shortVersion = $"{SanitizeVersion(infoPlist["CFBundleShortVersionString"] as PString)}.{buildNumber}";
             infoPlist.SetCFBundleShortVersionString(shortVersion);
-            File.WriteAllBytes(plistPath, infoPlist.ToByteArray(PropertyListFormat.Binary));
+            File.WriteAllBytes(outputPath, infoPlist.ToByteArray(PropertyListFormat.Xml));
         }
     }
 }

--- a/src/Mobile.BuildTools/Models/BuildToolsConfig.cs
+++ b/src/Mobile.BuildTools/Models/BuildToolsConfig.cs
@@ -40,6 +40,9 @@ namespace Mobile.BuildTools.Models
         [JsonProperty("projectSecrets")]
         public Dictionary<string, SecretsConfig> ProjectSecrets { get; set; }
 
+        [JsonProperty("environment")]
+        public EnvironmentSettings Environment { get; set; }
+
         [JsonProperty("debug")]
         public bool Debug { get; set; }
     }

--- a/src/Mobile.BuildTools/Models/EnvironmentSettings.cs
+++ b/src/Mobile.BuildTools/Models/EnvironmentSettings.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Mobile.BuildTools.Models
+{
+    public class EnvironmentSettings
+    {
+        [JsonProperty("defaults")]
+        public Dictionary<string, string> Defaults { get; set; }
+
+        [JsonProperty("configuration")]
+        public Dictionary<string, Dictionary<string, string>> Configuration { get; set; }
+    }
+}

--- a/src/Mobile.BuildTools/ReadMe.txt
+++ b/src/Mobile.BuildTools/ReadMe.txt
@@ -121,6 +121,16 @@ You can provide a solution wide configuration. The solution wide configuration m
     "Contoso.Android": {
       "AzureAdDataScheme": null // will use String by default
     }
+  },
+  "environment": {
+    "Debug": {
+      "AppId": "com.company.awesomeappdev",
+      "Backend": "https://dev.api.awesomeapp.com"
+    },
+    "Release": {
+      "AppId": "com.company.awesomeapp",
+      "Backend": "https://api.awesomeapp.com"
+    }
   }
 }
 ```

--- a/src/Mobile.BuildTools/Tasks/AutomaticBuildVersioningTask.cs
+++ b/src/Mobile.BuildTools/Tasks/AutomaticBuildVersioningTask.cs
@@ -14,6 +14,8 @@ namespace Mobile.BuildTools.Tasks
         [Required]
         public string ManifestPath { get; set; }
 
+        public string OutputManifestPath { get; set; }
+
         internal override void ExecuteInternal(IBuildConfiguration buildConfiguration)
         {
             if (buildConfiguration.Configuration.AutomaticVersioning.Behavior == VersionBehavior.Off)
@@ -46,33 +48,29 @@ namespace Mobile.BuildTools.Tasks
 
         private IGenerator GetGenerator(Platform platform)
         {
-            switch (platform)
+            return platform switch
             {
-                case Platform.Android:
-                    return new AndroidAutomaticBuildVersionGenerator(this, ManifestPath)
-                    {
-                        ReferenceAssemblyPaths = ReferenceAssemblyPaths
-                    };
-                case Platform.iOS:
-                case Platform.macOS:
-                    return new iOSAutomaticBuildVersionGenerator(this, ManifestPath);
-                default:
-                    return null;
-
-            }
+                Platform.Android => new AndroidAutomaticBuildVersionGenerator(this, ManifestPath, OutputManifestPath)
+                {
+                    ReferenceAssemblyPaths = ReferenceAssemblyPaths
+                },
+                Platform.iOS => new iOSAutomaticBuildVersionGenerator(this, ManifestPath, OutputManifestPath),
+                Platform.macOS => new iOSAutomaticBuildVersionGenerator(this, ManifestPath, OutputManifestPath),
+                Platform.TVOS => new iOSAutomaticBuildVersionGenerator(this, ManifestPath, OutputManifestPath),
+                _ => null
+            };
         }
 
         private bool IsSupported(Platform platform)
         {
-            switch(platform)
+            return platform switch
             {
-                case Platform.Android:
-                case Platform.iOS:
-                case Platform.macOS:
-                    return true;
-                default:
-                    return false;
-            }
+                Platform.Android => true,
+                Platform.iOS => true,
+                Platform.macOS => true,
+                Platform.TVOS => true,
+                _ => false
+            };
         }
     }
 }

--- a/src/Mobile.BuildTools/Tasks/BuildEnvironmentDumpTask.cs
+++ b/src/Mobile.BuildTools/Tasks/BuildEnvironmentDumpTask.cs
@@ -1,4 +1,10 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
+using Mobile.BuildTools.Build;
+using Mobile.BuildTools.Logging;
+using Mobile.BuildTools.Models;
+using Mobile.BuildTools.Models.Secrets;
+using Mobile.BuildTools.Utils;
 
 namespace Mobile.BuildTools.Tasks
 {
@@ -10,7 +16,8 @@ namespace Mobile.BuildTools.Tasks
 
         public override bool Execute()
         {
-            var variables = Utils.EnvironmentAnalyzer.GatherEnvironmentVariables(Configuration, ProjectDirectory, true);
+            var config = new BuildConfig(Configuration, ProjectDirectory);
+            var variables = Utils.EnvironmentAnalyzer.GatherEnvironmentVariables(config, true);
 
             string message;
             if (variables.Any())
@@ -29,6 +36,38 @@ namespace Mobile.BuildTools.Tasks
             Log.LogMessage(Microsoft.Build.Framework.MessageImportance.High, message);
 
             return true;
+        }
+
+        private class BuildConfig : IBuildConfiguration
+        {
+            public BuildConfig(string configuration, string projectDir)
+            {
+                BuildConfiguration = configuration;
+                ProjectDirectory = projectDir;
+                SolutionDirectory = EnvironmentAnalyzer.LocateSolution(projectDir);
+                Configuration = ConfigHelper.GetConfig(projectDir);
+            }
+
+            public string BuildConfiguration { get; }
+            public bool BuildingInsideVisualStudio { get; }
+            public IDictionary<string, string> GlobalProperties { get; }
+            public string ProjectName { get; }
+            public string ProjectDirectory { get; }
+            public string SolutionDirectory { get; }
+            public string IntermediateOutputPath { get; }
+            public ILog Logger { get; }
+            public BuildToolsConfig Configuration { get; }
+            public Platform Platform { get; }
+
+            public SecretsConfig GetSecretsConfig()
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public void SaveConfiguration()
+            {
+                throw new System.NotImplementedException();
+            }
         }
     }
 }

--- a/src/Mobile.BuildTools/Tasks/TemplateManifestTask.cs
+++ b/src/Mobile.BuildTools/Tasks/TemplateManifestTask.cs
@@ -33,10 +33,17 @@ namespace Mobile.BuildTools.Tasks
                 return;
             }
 
+            if (string.IsNullOrEmpty(OutputManifestPath))
+            {
+                OutputManifestPath = ManifestPath;
+            }
+
             IGenerator<string> generator = null;
             switch(config.Platform)
             {
                 case Platform.iOS:
+                case Platform.macOS:
+                case Platform.TVOS:
                     generator = new TemplatedPlistGenerator(config)
                     {
                         ManifestInputPath = ManifestPath,
@@ -47,7 +54,7 @@ namespace Mobile.BuildTools.Tasks
                     generator = new TemplatedAndroidAppManifestGenerator(config, ReferenceAssemblyPaths)
                     {
                         ManifestInputPath = ManifestPath,
-                        ManifestOutputPath = ManifestPath
+                        ManifestOutputPath = OutputManifestPath
                     };
                     break;
             }

--- a/tests/Mobile.BuildTools.Tests/Fixtures/Generators/AndroidAutomaticBuildVersionGeneratorFixture.cs
+++ b/tests/Mobile.BuildTools.Tests/Fixtures/Generators/AndroidAutomaticBuildVersionGeneratorFixture.cs
@@ -28,7 +28,7 @@ namespace Mobile.BuildTools.Tests.Fixtures.Generators
 
             File.Copy(TemplateAndroidManifestPath, TemplateAndroidManifestOutputPath);
 
-            return new AndroidAutomaticBuildVersionGenerator(GetConfiguration(), TemplateAndroidManifestOutputPath);
+            return new AndroidAutomaticBuildVersionGenerator(GetConfiguration(), TemplateAndroidManifestPath, TemplateAndroidManifestOutputPath);
         }
 
         //[Fact]

--- a/tests/Mobile.BuildTools.Tests/Fixtures/Generators/AppManifestGeneratorFixture.cs
+++ b/tests/Mobile.BuildTools.Tests/Fixtures/Generators/AppManifestGeneratorFixture.cs
@@ -61,7 +61,13 @@ namespace Mobile.BuildTools.Tests.Fixtures.Generators
             var generator = CreateGenerator();
             var template = File.ReadAllText(TemplateManifestPath);
             var match = generator.GetMatches(template).Cast<Match>().FirstOrDefault();
-            var variables = EnvironmentAnalyzer.GatherEnvironmentVariables("Test", Directory.GetCurrentDirectory(), true);
+            var config = new TestBuildConfiguration
+            {
+                BuildConfiguration = "Test",
+                ProjectDirectory = Directory.GetCurrentDirectory(),
+                SolutionDirectory = Directory.GetCurrentDirectory()
+            };
+            var variables = EnvironmentAnalyzer.GatherEnvironmentVariables(config, true);
             foreach(var variable in variables)
             {
                 _testOutputHelper.WriteLine($"  - {variable.Key}: {variable.Value}");
@@ -81,12 +87,14 @@ namespace Mobile.BuildTools.Tests.Fixtures.Generators
         public void ProcessCustomTokenizedVariables()
         {
             var config = GetConfiguration();
+            config.BuildConfiguration = "Test";
+            config.ProjectDirectory = config.SolutionDirectory = Directory.GetCurrentDirectory();
             config.Configuration.Manifests.Token = @"%%";
             var generator = CreateGenerator(config);
 
             var template = File.ReadAllText(TemplateManifestPath);
             var match = generator.GetMatches(template).Cast<Match>().FirstOrDefault();
-            var variables = EnvironmentAnalyzer.GatherEnvironmentVariables("Test", Directory.GetCurrentDirectory(), true);
+            var variables = EnvironmentAnalyzer.GatherEnvironmentVariables(config, true);
             var processedTemplate = generator.ProcessMatch(template, match, variables);
             var json = JsonConvert.DeserializeAnonymousType(processedTemplate, new
             {


### PR DESCRIPTION
# Description

Adds the ability to add non-sensitive default values to the buildtools.json that are used by the Secrets class generator and the template manifest task. This allows both generically default variables and build configuration based variables.

The defaults can now be added in the buildtools.json as follows:

```json
{
  "environment": {
    "defaults": {
      "AppId": "com.avantipoint.awesomeapp"
    },
    "configuration": {
      "Debug": {
        "AppId": "com.avantipoint.awesomeappdev"
      }
    }
  }
}
```

Given this sample I might tokenize the package name in the AndroidManifest or the CFBundleIdentifier in the Info.plist, this would then allow me to automatically set the name to `com.avantipoint.awesomeappdev` while debugging the app, and `com.avantipoint.awesomeapp` on all other builds. As a result I can easily ensure that I can deploy side by side instances of the app.

## Issues 

- Fixed issue with AndroidManifest only getting updated on subsequent builds. All manifest updates will now occur on a clean (first) build.
- fixes #153
- closes #120 - this is really a better approach