### PR TITLE
#172 Configure generated Secrets class accessibility

### DIFF
--- a/src/Mobile.BuildTools/Generators/Secrets/SecretsClassGenerator.cs
+++ b/src/Mobile.BuildTools/Generators/Secrets/SecretsClassGenerator.cs
@@ -195,7 +195,7 @@ namespace Mobile.BuildTools.Generators.Secrets
             using (writer.Block($"namespace {GetNamespace(secretsConfig.Namespace)}"))
             {
                 writer.AppendAttribute(CompileGeneratedAttribute);
-                using(writer.Block($"static partial class {secretsConfig.ClassName}"))
+                using(writer.Block($"{secretsConfig.Accessibility.ToString().ToLower()} static partial class {secretsConfig.ClassName}"))
                 {
                     foreach (var secret in secrets)
                     {
@@ -227,9 +227,10 @@ namespace Mobile.BuildTools.Generators.Secrets
             }
 
             var mapping = valueConfig.PropertyType.GetPropertyTypeMapping();
+            var accessibility = secretsConfig.Accessibility.ToString().ToLower();
 
-            var standardOutput = PropertyBuilder(secret, mapping.Type, mapping.Handler, valueConfig.IsArray, false);
-            var safeOutput = PropertyBuilder(secret, mapping.Type, mapping.Handler, valueConfig.IsArray, true);
+            var standardOutput = PropertyBuilder(secret, mapping.Type, mapping.Handler, valueConfig.IsArray, false, accessibility);
+            var safeOutput = PropertyBuilder(secret, mapping.Type, mapping.Handler, valueConfig.IsArray, true, accessibility);
             writer.AppendAttribute(CompileGeneratedAttribute);
             writer.AppendLine(standardOutput, safeOutput);
         }
@@ -253,7 +254,9 @@ namespace Mobile.BuildTools.Generators.Secrets
             }
 
             var mapping = valueConfig.PropertyType.GetPropertyTypeMapping();
-            return PropertyBuilder(secret, mapping.Type, mapping.Handler, valueConfig.IsArray, safeOutput);
+            var accessibility = secretsConfig.Accessibility.ToString().ToLower();
+
+            return PropertyBuilder(secret, mapping.Type, mapping.Handler, valueConfig.IsArray, safeOutput, accessibility);
         }
 
         internal ValueConfig GenerateValueConfig(KeyValuePair<string, string> secret, SecretsConfig config)
@@ -308,7 +311,7 @@ namespace Mobile.BuildTools.Generators.Secrets
             return $"{BaseNamespace}.{relativeNamespace}";
         }
 
-        internal string PropertyBuilder(KeyValuePair<string, string> secret, Type type, IValueHandler valueHandler, bool isArray, bool safeOutput)
+        internal string PropertyBuilder(KeyValuePair<string, string> secret, Type type, IValueHandler valueHandler, bool isArray, bool safeOutput, string accessibility)
         {
             var output = string.Empty;
             var typeDeclaration = type.GetStandardTypeName();
@@ -329,7 +332,7 @@ namespace Mobile.BuildTools.Generators.Secrets
                 output = output.ToLower();
             }
 
-            return $"internal {accessModifier} {typeDeclaration} {secret.Key} = {output};";
+            return $"{accessibility} {accessModifier} {typeDeclaration} {secret.Key} = {output};";
         }
 
         internal static IEnumerable<string> GetValueArray(JToken token) =>

--- a/src/Mobile.BuildTools/Models/Secrets/Accessibility.cs
+++ b/src/Mobile.BuildTools/Models/Secrets/Accessibility.cs
@@ -1,0 +1,9 @@
+﻿
+namespace Mobile.BuildTools.Models.Secrets
+{
+    public enum Accessibility
+    {
+        Internal,
+        Public
+    }
+}

--- a/src/Mobile.BuildTools/Models/Secrets/SecretsConfig.cs
+++ b/src/Mobile.BuildTools/Models/Secrets/SecretsConfig.cs
@@ -18,6 +18,15 @@ namespace Mobile.BuildTools.Models.Secrets
         [JsonProperty("className")]
         public string ClassName { get; set; }
 
+#if SCHEMAGENERATOR
+        [System.ComponentModel.DefaultValue("Internal")]
+        [System.ComponentModel.DataAnnotations.EnumDataType(typeof(Accessibility))]
+        public string Accessibility { get; set; }
+#else
+        [JsonProperty("accessibility")]
+        public Accessibility Accessibility { get; set; }
+#endif
+
         [JsonProperty("namespace")]
         public string Namespace { get; set; }
 

--- a/tests/Mobile.BuildTools.Tests/Fixtures/Generators/SecretsClassGeneratorFixture.cs
+++ b/tests/Mobile.BuildTools.Tests/Fixtures/Generators/SecretsClassGeneratorFixture.cs
@@ -55,9 +55,11 @@ namespace Mobile.BuildTools.Tests.Fixtures.Generators
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void ProcessSecretGeneratesBooleanValue(bool firstRun)
+        [InlineData(Accessibility.Internal, true)]
+        [InlineData(Accessibility.Internal, false)]
+        [InlineData(Accessibility.Public, true)]
+        [InlineData(Accessibility.Public, false)]
+        public void ProcessSecretGeneratesBooleanValue(Accessibility accessibility, bool firstRun)
         {
             var key = "TestKey";
             var value = bool.TrueString;
@@ -65,17 +67,20 @@ namespace Mobile.BuildTools.Tests.Fixtures.Generators
             var generator = GetGenerator();
             var config = new SecretsConfig()
             {
+                Accessibility = accessibility,
                 Properties = new List<ValueConfig> { new ValueConfig { Name = TestKey, PropertyType = PropertyType.Bool } }
             };
 
             var output = generator.ProcessSecret(pair, config, firstRun);
-            Assert.Contains($"const bool {key}", output);
+            Assert.Contains($"{accessibility.ToString().ToLower()} const bool {key}", output);
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void ProcessSecretGeneratesIntegerValue(bool firstRun)
+        [InlineData(Accessibility.Internal, true)]
+        [InlineData(Accessibility.Internal, false)]
+        [InlineData(Accessibility.Public, true)]
+        [InlineData(Accessibility.Public, false)]
+        public void ProcessSecretGeneratesIntegerValue(Accessibility accessibility, bool firstRun)
         {
             var key = "TestKey";
             var value = "2";
@@ -83,17 +88,20 @@ namespace Mobile.BuildTools.Tests.Fixtures.Generators
             var generator = GetGenerator();
             var config = new SecretsConfig()
             {
+                Accessibility = accessibility,
                 Properties = new List<ValueConfig> { new ValueConfig { Name = TestKey, PropertyType = PropertyType.Int } }
             };
 
             var output = generator.ProcessSecret(pair, config, firstRun);
-            Assert.Contains($"const int {key}", output);
+            Assert.Contains($"{accessibility.ToString().ToLower()} const int {key}", output);
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void ProcessSecretGeneratesDoubleValue(bool firstRun)
+        [InlineData(Accessibility.Internal, true)]
+        [InlineData(Accessibility.Internal, false)]
+        [InlineData(Accessibility.Public, true)]
+        [InlineData(Accessibility.Public, false)]
+        public void ProcessSecretGeneratesDoubleValue(Accessibility accessibility, bool firstRun)
         {
             var key = "TestKey";
             var value = "2.2";
@@ -101,17 +109,20 @@ namespace Mobile.BuildTools.Tests.Fixtures.Generators
             var generator = GetGenerator();
             var config = new SecretsConfig()
             {
+                Accessibility = accessibility,
                 Properties = new List<ValueConfig> { new ValueConfig { Name = TestKey, PropertyType = PropertyType.Double } }
             };
 
             var output = generator.ProcessSecret(pair, config, firstRun);
-            Assert.Contains($"const double {key}", output);
+            Assert.Contains($"{accessibility.ToString().ToLower()} const double {key}", output);
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void ProcessSecretGeneratesStringValue(bool firstRun)
+        [InlineData(Accessibility.Internal, true)]
+        [InlineData(Accessibility.Internal, false)]
+        [InlineData(Accessibility.Public, true)]
+        [InlineData(Accessibility.Public, false)]
+        public void ProcessSecretGeneratesStringValue(Accessibility accessibility, bool firstRun)
         {
             var key = "TestKey";
             var value = "TestValue";
@@ -119,11 +130,12 @@ namespace Mobile.BuildTools.Tests.Fixtures.Generators
             var generator = GetGenerator();
             var config = new SecretsConfig()
             {
+                Accessibility = accessibility,
                 Properties = new List<ValueConfig> { new ValueConfig { Name = TestKey, PropertyType = PropertyType.String } }
             };
 
             var output = generator.ProcessSecret(pair, config, firstRun);
-            Assert.Contains($"const string {key}", output);
+            Assert.Contains($"{accessibility.ToString().ToLower()} const string {key}", output);
         }
 
         [Theory]


### PR DESCRIPTION
PR for #172.

Adds the ability to configure the generated Secrets class and property accessibility level to one of the following values:

- `Internal` - default value
- `Public`