### PR TITLE
add support for Root Namespace

### DIFF
--- a/docs/schemas/v2/buildtools.schema.json
+++ b/docs/schemas/v2/buildtools.schema.json
@@ -249,6 +249,13 @@
           ],
           "default": "Helpers"
         },
+        "rootNamespace": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "An override to the project root namespace. This may be useful if using a Shared project."
+        },
         "properties": {
           "type": [
             "array",

--- a/src/Mobile.BuildTools/Models/Secrets/SecretsConfig.cs
+++ b/src/Mobile.BuildTools/Models/Secrets/SecretsConfig.cs
@@ -27,6 +27,9 @@ namespace Mobile.BuildTools.Models.Secrets
         public Accessibility Accessibility { get; set; }
 #endif
 
+        [JsonProperty("rootNamespace")]
+        public string RootNamespace { get; set; }
+
         [JsonProperty("namespace")]
         public string Namespace { get; set; }
 

--- a/src/Mobile.BuildTools/Tasks/SecretsJsonTask.cs
+++ b/src/Mobile.BuildTools/Tasks/SecretsJsonTask.cs
@@ -22,7 +22,8 @@ namespace Mobile.BuildTools.Tasks
         {
             //System.Diagnostics.Debugger.Launch();
 
-            if (config.GetSecretsConfig().Disable)
+            var secretsConfig = config.GetSecretsConfig();
+            if (secretsConfig is null || secretsConfig.Disable)
                 return;
 
             var configJson = string.Format(Constants.SecretsJsonConfigurationFileFormat, config.BuildConfiguration.ToLower());
@@ -39,9 +40,10 @@ namespace Mobile.BuildTools.Tasks
             if (!string.IsNullOrEmpty(JsonSecretsFilePath) && !searchPaths.Contains(JsonSecretsFilePath))
                 searchPaths.Add(JsonSecretsFilePath);
 
+            var rootNamespace = string.IsNullOrEmpty(secretsConfig.RootNamespace) ? RootNamespace : secretsConfig.RootNamespace;
             var generator = new SecretsClassGenerator(config, searchPaths.ToArray())
             {
-                BaseNamespace = RootNamespace,
+                BaseNamespace = rootNamespace,
             };
             generator.Execute();
             _generatedCodeFiles = new[] { generator.Outputs };


### PR DESCRIPTION
# Description

Adds support for setting a Root namespace to use for the Secrets class generation. This will override the default Root namespace of the project. This can be used in cases where you need to access the Secrets class from a shared project used across multiple platform heads which would each have a different Root Namespace.

- fixes #210