### PR TITLE
add support for transitive build

### DIFF
--- a/src/Mobile.BuildTools/Mobile.BuildTools.csproj
+++ b/src/Mobile.BuildTools/Mobile.BuildTools.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <None Include="..\assets\runtimes\**\libsass.*" Pack="true" PackagePath="$(PrimaryOutputKind)/runtimes/%(RecursiveDir)%(Filename)%(Extension)" />
     <None Include="*.targets;*.props" Pack="true" Kind="$(PrimaryOutputKind)" />
+    <None Update="buildTransitive\*.targets;buildTransitive\*.props" Pack="true" Kind="buildTransitive" />
     <None Update="Resources\*" Pack="true" PackagePath="$(PrimaryOutputKind)/resources/%(Filename)%(Extension)" />
     <None Update="ReadMe.txt" Pack="true" PackagePath="ReadMe.txt" />
   </ItemGroup>

--- a/src/Mobile.BuildTools/buildTransitive/Mobile.BuildTools.props
+++ b/src/Mobile.BuildTools/buildTransitive/Mobile.BuildTools.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\build\Mobile.BuildTools.props" />
+</Project>

--- a/src/Mobile.BuildTools/buildTransitive/Mobile.BuildTools.targets
+++ b/src/Mobile.BuildTools/buildTransitive/Mobile.BuildTools.targets
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\build\Mobile.BuildTools.targets" />
+</Project>


### PR DESCRIPTION
# Description

Adds build props / targets to buildTransitive directory of the package. This will allow other packages to reference Mobile.BuildTools and have the build targets still automatically imported.

- closes #122