### PR TITLE
prevent null references

### DIFF
--- a/src/Mobile.BuildTools/Models/EnvironmentSettings.cs
+++ b/src/Mobile.BuildTools/Models/EnvironmentSettings.cs
@@ -5,6 +5,12 @@ namespace Mobile.BuildTools.Models
 {
     public class EnvironmentSettings
     {
+        public EnvironmentSettings()
+        {
+            Defaults = new Dictionary<string, string>();
+            Configuration = new Dictionary<string, Dictionary<string, string>>();
+        }
+
         [JsonProperty("defaults")]
         public Dictionary<string, string> Defaults { get; set; }
 

--- a/src/Mobile.BuildTools/Models/ImageResize.cs
+++ b/src/Mobile.BuildTools/Models/ImageResize.cs
@@ -6,6 +6,12 @@ namespace Mobile.BuildTools.Models
 {
     public class ImageResize : ToolItem
     {
+        public ImageResize()
+        {
+            Directories = new List<string>();
+            ConditionalDirectories = new Dictionary<string, IEnumerable<string>>();
+        }
+
         [JsonProperty("directories")]
         public List<string> Directories { get; set; }
 

--- a/src/Mobile.BuildTools/Models/Secrets/SecretsConfig.cs
+++ b/src/Mobile.BuildTools/Models/Secrets/SecretsConfig.cs
@@ -6,6 +6,11 @@ namespace Mobile.BuildTools.Models.Secrets
 {
     public class SecretsConfig
     {
+        public SecretsConfig()
+        {
+            Properties = new List<ValueConfig>();
+        }
+
         [JsonProperty("disable")]
         public bool Disable { get; set; }
 


### PR DESCRIPTION
# Description

When reading the buildtools.json the helper does activate any null values, however this does not address any collections which we may expect to iterate on. This ensures that when creating a new instance of our config sections they initialize any collections that they contain so we avoid any unnecessary null reference exceptions