### PR TITLE
Migrated Svg.Picture to it's replacement Svg.Model

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -9,11 +9,12 @@
 
     <PackageReference Update="Fizzler" Version="1.3.0" />
     <PackageReference Update="HarfBuzzSharp" Version="2.6.1.7" />
+    <PackageReference Update="ShimSkiaSharp" Version="0.5.5.5" />
     <PackageReference Update="SkiaSharp" Version="2.80.2" />
     <PackageReference Update="SkiaSharp.HarfBuzz" Version="2.80.2" />
     <PackageReference Update="Svg.Skia" Version="0.5.5.5" />
     <PackageReference Update="Svg.Custom" Version="0.5.5.5" />
-    <PackageReference Update="Svg.Picture" Version="0.4.1" />
+    <PackageReference Update="Svg.Model" Version="0.5.5.5" />
     <PackageReference Update="System.Buffers" Version="4.5.1" />
     <PackageReference Update="System.Drawing.Common" Version="5.0.2" />
     <PackageReference Update="System.IO.UnmanagedMemoryStream" Version="4.3.0" />

--- a/src/Mobile.BuildTools/Mobile.BuildTools.csproj
+++ b/src/Mobile.BuildTools/Mobile.BuildTools.csproj
@@ -36,11 +36,12 @@
     <PackageReference Include="Newtonsoft.Json" PrivateAssets="all" />
     <PackageReference Include="NuGet.Build.Packaging" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Web.Xdt" PrivateAssets="all" />
+    <PackageReference Include="ShimSkiaSharp" PrivateAssets="all" />
     <PackageReference Include="SkiaSharp" PrivateAssets="all" />
     <PackageReference Include="SkiaSharp.HarfBuzz" PrivateAssets="all" />
     <PackageReference Include="Svg.Skia" PrivateAssets="all" />
     <PackageReference Include="Svg.Custom" PrivateAssets="all" />
-    <PackageReference Include="Svg.Picture" PrivateAssets="all" />
+    <PackageReference Include="Svg.Model" PrivateAssets="all" />
     <PackageReference Include="System.Buffers" PrivateAssets="all" />
     <PackageReference Include="System.Drawing.Common" PrivateAssets="all" />
     <PackageReference Include="System.IO.UnmanagedMemoryStream" PrivateAssets="all" />


### PR DESCRIPTION
This resolves a build lock up or 'unknown build failure' when building iOS/Android and using SVG images