### PR TITLE
Move app.config props

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <PackageReference Update="Prism.DryIoc.Forms" Version="8.1.97" />
-    <PackageReference Update="Xamarin.Forms" Version="4.8.0.1451" />
+    <PackageReference Update="Xamarin.Forms" Version="5.0.0.2012" />
     <PackageReference Update="Xamarin.Forms.Mocks" Version="4.7.0.1" />
     <PackageReference Update="Xamarin.Essentials" Version="1.6.1" />
     <PackageReference Update="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.12" />

--- a/src/Mobile.BuildTools.Configuration/Mobile.BuildTools.Configuration.csproj
+++ b/src/Mobile.BuildTools.Configuration/Mobile.BuildTools.Configuration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;MonoAndroid80;MonoAndroid81;MonoAndroid90;MonoAndroid10.0;Xamarin.iOS10;Xamarin.Mac20;Xamarin.TVOS10;tizen40;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;MonoAndroid81;MonoAndroid90;MonoAndroid10.0;Xamarin.iOS10;Xamarin.Mac20;Xamarin.TVOS10;tizen40;netcoreapp3.1</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);uap10.0.16299</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -51,6 +51,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Web.Xdt" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="build\*.props" Pack="true" PackagePath="build" />
   </ItemGroup>
 
 </Project>

--- a/src/Mobile.BuildTools.Configuration/build/Mobile.BuildTools.Configuration.props
+++ b/src/Mobile.BuildTools.Configuration/build/Mobile.BuildTools.Configuration.props
@@ -1,0 +1,8 @@
+﻿<Project>
+  <ItemGroup Condition=" Exists('app.config') ">
+    <None Remove="app.config" />
+    <None Remove="app.*.config" />
+    <MobileBuildToolsConfig Include="app.config" Visible="true" IsRootConfig="true" />
+    <MobileBuildToolsConfig Include="app.*.config" DependentUpon="app.config" Visible="true" />
+  </ItemGroup>
+</Project>

--- a/src/Mobile.BuildTools.Reference/Mobile.BuildTools.Reference.csproj
+++ b/src/Mobile.BuildTools.Reference/Mobile.BuildTools.Reference.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net472;</TargetFrameworks>

--- a/src/Mobile.BuildTools/Mobile.BuildTools.props
+++ b/src/Mobile.BuildTools/Mobile.BuildTools.props
@@ -136,11 +136,4 @@
     <DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition=" Exists('app.config') ">
-    <None Remove="app.config" />
-    <None Remove="app.*.config" />
-    <MobileBuildToolsConfig Include="app.config" Visible="true" IsRootConfig="true" />
-    <MobileBuildToolsConfig Include="app.*.config" DependentUpon="app.config" Visible="true" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
# Description

There is currently a pretty loose connection between Mobile.BuildTools and Mobile.BuildTools.Configuration. This kept all of the build props/targets as part of the Mobile.BuildTools... it also results in a pretty annoying inclusion of the app.config on the iOS/Android project even when the file does not exist. This updates the props so that it is now part of the Configuration project, and you will only get the Include when you actually have the Configuration package referenced.

There isn't really anything I can do for the file showing up. The legacy project sdk's for Android/iOS aren't as capable of dynamic includes like the newer MSBuild Sdks