### PR TITLE
Support AAB copy

### DIFF
--- a/src/Mobile.BuildTools/MonoAndroid.targets
+++ b/src/Mobile.BuildTools/MonoAndroid.targets
@@ -11,7 +11,7 @@
           BeforeTargets="APKCopyToStagingDirectory">
 
     <ItemGroup>
-      <__Generated_APK Include="$(OutputPath)\**\*.apk" />
+      <__Generated_APK Include="$(OutputPath)\**\*.$(AndroidPackageFormat)" />
     </ItemGroup>
 
     <Message Text="@(__Generated_APK)" />


### PR DESCRIPTION
# Description

Adds Support for copying generated AAB or APK for Android Projects to the Artifacts folder.

- Fixes #211 