### PR TITLE
Safely handle no build tools.json config file

### DIFF
--- a/src/Mobile.BuildTools.Reference/Utils/ConfigHelper.shared.cs
+++ b/src/Mobile.BuildTools.Reference/Utils/ConfigHelper.shared.cs
@@ -52,9 +52,14 @@ namespace Mobile.BuildTools.Utils
         public static BuildToolsConfig GetConfig(string path)
         {
             var filePath = GetConfigurationPath(path);
-            if(File.GetAttributes(filePath).HasFlag(FileAttributes.Directory))
+            if (File.GetAttributes(filePath).HasFlag(FileAttributes.Directory))
             {
                 filePath = Path.Combine(filePath, "buildtools.json");
+            }
+
+            if (!Exists(filePath))
+            {
+                SaveDefaultConfig(filePath);
             }
 
             var json = string.Empty;

--- a/src/Mobile.BuildTools.Reference/Utils/ConfigHelper.shared.cs
+++ b/src/Mobile.BuildTools.Reference/Utils/ConfigHelper.shared.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -18,7 +19,7 @@ namespace Mobile.BuildTools.Utils
             if (string.IsNullOrEmpty(searchDirectory)) return null;
 
             var rootPath = Path.GetPathRoot(searchDirectory);
-            var configPath = new FileInfo(Path.Combine(searchDirectory, "buildtools.json"));
+            var configPath = new FileInfo(Path.Combine(searchDirectory, Constants.BuildToolsConfigFileName));
             if (configPath.Exists)
             {
                 return searchDirectory;
@@ -52,14 +53,15 @@ namespace Mobile.BuildTools.Utils
         public static BuildToolsConfig GetConfig(string path)
         {
             var filePath = GetConfigurationPath(path);
+            var configurationDirectoryPath = filePath;
             if (File.GetAttributes(filePath).HasFlag(FileAttributes.Directory))
             {
-                filePath = Path.Combine(filePath, "buildtools.json");
+                filePath = Path.Combine(filePath, Constants.BuildToolsConfigFileName);
             }
 
-            if (!Exists(filePath))
+            if (!Exists(configurationDirectoryPath))
             {
-                SaveDefaultConfig(filePath);
+                SaveDefaultConfig(configurationDirectoryPath);
             }
 
             var json = string.Empty;

--- a/tests/Mobile.BuildTools.Tests/Fixtures/Utils/BuildToolsConfigFixture.cs
+++ b/tests/Mobile.BuildTools.Tests/Fixtures/Utils/BuildToolsConfigFixture.cs
@@ -1,26 +1,26 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
-using System.Text;
+using Mobile.BuildTools.Models;
 using Mobile.BuildTools.Utils;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Mobile.BuildTools.Tests.Fixtures.Utils
 {
-    public sealed class BuildToolsConfigFixture : IDisposable
+    public sealed class BuildToolsConfigFixture : FixtureBase
     {
         private static readonly string MockEmptyConfigPath = Path.Combine(Environment.CurrentDirectory, nameof(BuildToolsConfigFixture));
 
-        public BuildToolsConfigFixture()
+        public BuildToolsConfigFixture(ITestOutputHelper testOutputHelper)
+            : base(MockEmptyConfigPath, testOutputHelper)
         {
-            Directory.CreateDirectory(MockEmptyConfigPath);
-            ConfigHelper.SaveDefaultConfig(MockEmptyConfigPath);
         }
 
         [Fact]
         public void AppConfigIsNotNull()
         {
-            var config = ConfigHelper.GetConfig(MockEmptyConfigPath);
+            var config = CreateConfig();
 
             Assert.NotNull(config.AppConfig);
         }
@@ -28,7 +28,7 @@ namespace Mobile.BuildTools.Tests.Fixtures.Utils
         [Fact]
         public void ArtifactCopyIsNotNull()
         {
-            var config = ConfigHelper.GetConfig(MockEmptyConfigPath);
+            var config = CreateConfig();
 
             Assert.NotNull(config.ArtifactCopy);
         }
@@ -36,7 +36,7 @@ namespace Mobile.BuildTools.Tests.Fixtures.Utils
         [Fact]
         public void AutomaticVersioningIsNotNull()
         {
-            var config = ConfigHelper.GetConfig(MockEmptyConfigPath);
+            var config = CreateConfig();
 
             Assert.NotNull(config.AutomaticVersioning);
         }
@@ -44,7 +44,7 @@ namespace Mobile.BuildTools.Tests.Fixtures.Utils
         [Fact]
         public void CssIsNotNull()
         {
-            var config = ConfigHelper.GetConfig(MockEmptyConfigPath);
+            var config = CreateConfig();
 
             Assert.NotNull(config.Css);
         }
@@ -52,7 +52,7 @@ namespace Mobile.BuildTools.Tests.Fixtures.Utils
         [Fact]
         public void ImagesIsNotNull()
         {
-            var config = ConfigHelper.GetConfig(MockEmptyConfigPath);
+            var config = CreateConfig();
 
             Assert.NotNull(config.Images);
         }
@@ -60,7 +60,7 @@ namespace Mobile.BuildTools.Tests.Fixtures.Utils
         [Fact]
         public void ManifestsIsNotNull()
         {
-            var config = ConfigHelper.GetConfig(MockEmptyConfigPath);
+            var config = CreateConfig();
 
             Assert.NotNull(config.Manifests);
         }
@@ -68,7 +68,7 @@ namespace Mobile.BuildTools.Tests.Fixtures.Utils
         [Fact]
         public void ProjectSecretsIsNotNull()
         {
-            var config = ConfigHelper.GetConfig(MockEmptyConfigPath);
+            var config = CreateConfig();
 
             Assert.NotNull(config.ProjectSecrets);
         }
@@ -76,17 +76,20 @@ namespace Mobile.BuildTools.Tests.Fixtures.Utils
         [Fact]
         public void ReleaseNotesIsNotNull()
         {
-            var config = ConfigHelper.GetConfig(MockEmptyConfigPath);
+            var config = CreateConfig();
 
             Assert.NotNull(config.ReleaseNotes);
         }
 
-        public void Dispose()
+        private BuildToolsConfig CreateConfig()
         {
-            if(File.Exists(MockEmptyConfigPath))
-            {
-                File.Delete(MockEmptyConfigPath);
-            }
+            var stackTrace = new StackTrace();
+            var configuration = GetConfiguration(stackTrace.GetFrame(1).GetMethod().Name);
+            CreateDummySolutionFile(configuration.IntermediateOutputPath);
+
+            return ConfigHelper.GetConfig(configuration.IntermediateOutputPath);
         }
+
+        private static void CreateDummySolutionFile(string directory) => File.Create(Path.Combine(directory, "test.sln"));
     }
 }


### PR DESCRIPTION
This resolves #259 

Reworked unit tests to rely on the logic that creates the default file within the framework rather than creating it upfront.