### PR TITLE
Disabled config validation

### DIFF
--- a/src/Mobile.BuildTools/Tasks/LocateBuildToolsConfigTask.cs
+++ b/src/Mobile.BuildTools/Tasks/LocateBuildToolsConfigTask.cs
@@ -67,7 +67,7 @@ namespace Mobile.BuildTools.Tasks
             LocateSolution();
             BuildToolsConfigFilePath = ConfigHelper.GetConfigurationPath(ProjectDir);
             MigrateSecretsToSettings();
-            ValidateConfigSchema();
+            //ValidateConfigSchema();
 
             var crossTargetingProject = IsCrossTargeting();
             var platform = TargetFrameworkIdentifier.GetTargetPlatform();
@@ -89,7 +89,7 @@ namespace Mobile.BuildTools.Tasks
 
             return true;
         }
-
+        
         internal void ValidateConfigSchema()
         {
             try


### PR DESCRIPTION
Disables the `buildtools.json` config file validation to workaround #263 