### PR TITLE
Resolve issue 285 watermark image

### DIFF
--- a/src/Mobile.BuildTools.Reference/Generators/Images/AppleImageCollectionGenerator.cs
+++ b/src/Mobile.BuildTools.Reference/Generators/Images/AppleImageCollectionGenerator.cs
@@ -66,6 +66,7 @@ namespace Mobile.BuildTools.Generators.Images
            else
            {
                 Log.LogMessage($"Found image {config.SourceFile} -> Resources/{config.Name}.png");
+
                 // Generate App Resources
                 return ResourceSizes.Select(x => new OutputImage
                 {
@@ -131,7 +132,6 @@ namespace Mobile.BuildTools.Generators.Images
             Log.LogMessage($"Found App Icon Set image {resource.SourceFile} -> {basePath}{Path.DirectorySeparatorChar}{x.FileName}");
             var outputFile = Path.Combine(Build.IntermediateOutputPath, basePath, x.FileName);
             var outputLink = Path.Combine(basePath, x.FileName);
-            var watermarkFilePath = GetWatermarkFilePath(resource);
             var width = (int)(double.Parse(size[0]) * scale);
             var height = (int)(double.Parse(size[1]) * scale);
             return new OutputImage
@@ -143,7 +143,6 @@ namespace Mobile.BuildTools.Generators.Images
                 Height = height,
                 RequiresBackgroundColor = outputFileName == "AppIcon",
                 ShouldBeVisible = false,
-                //WatermarkFilePath = watermarkFilePath,
                 Watermark = resource.Watermark,
                 BackgroundColor = resource.BackgroundColor,
                 BuildAction = "ImageAsset"

--- a/src/Mobile.BuildTools.Reference/Generators/Images/ImageCollectionGeneratorBase.cs
+++ b/src/Mobile.BuildTools.Reference/Generators/Images/ImageCollectionGeneratorBase.cs
@@ -48,7 +48,7 @@ namespace Mobile.BuildTools.Generators.Images
                     if (inputFileNames.Any(x => x == fileName))
                     {
                         var originalFile = imageResourcePaths.First(x => Path.GetFileNameWithoutExtension(x) == fileName);
-                        Log.LogWarning($"Found duplicate input image '{fileName}'. Originial input path '{originalFile}', and duplicate file path '{file}'.");
+                        Log.LogWarning($"Found duplicate input image '{fileName}'. Original input path '{originalFile}', and duplicate file path '{file}'.");
                         continue;
                     }
 
@@ -57,7 +57,7 @@ namespace Mobile.BuildTools.Generators.Images
 
                     var jsonConfig = Path.Combine(Path.GetDirectoryName(file), $"{fileName}.json");
 
-                    if(!File.Exists(jsonConfig))
+                    if (!File.Exists(jsonConfig))
                     {
                         var resourceJson = new FileInfo(jsonConfig);
                         using var fs = resourceJson.Create();
@@ -79,13 +79,13 @@ namespace Mobile.BuildTools.Generators.Images
             }
 
             var inputList = imageResourcePaths.ToArray();
-            foreach(var path in inputList)
+            foreach (var path in inputList)
             {
                 // We need to iterate a second time so we can be sure we are
                 // tracking all of the image files
                 var resourceDefinition = GetResourceDefinition(path);
                 var configs = resourceDefinition.GetConfigurations(Build.Platform);
-                foreach(var config in configs)
+                foreach (var config in configs)
                 {
                     if (config.Ignore)
                         continue;
@@ -95,10 +95,15 @@ namespace Mobile.BuildTools.Generators.Images
                     {
                         if (System.Diagnostics.Debugger.IsAttached)
                             System.Diagnostics.Debugger.Break();
-                        else if(!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                        else if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                             System.Diagnostics.Debugger.Launch();
                     }
 #endif
+
+                    if (config.Watermark != null)
+                    {
+                        config.Watermark.SourceFile = GetWatermarkFilePath(config);
+                    }
 
                     var output = GetOutputImages(config);
                     if (output != null && output.Any())
@@ -164,7 +169,7 @@ namespace Mobile.BuildTools.Generators.Images
             {
                 definition.Scale = 1;
             }
-            else if(definition.Scale > 1)
+            else if (definition.Scale > 1)
             {
                 do
                 {

--- a/src/Mobile.BuildTools.Reference/Utils/ConfigHelper.cs
+++ b/src/Mobile.BuildTools.Reference/Utils/ConfigHelper.cs
@@ -103,13 +103,16 @@ appsettings.json
 appsettings.*.json
 ";
             var gitignoreFile = Path.Combine(path, ".gitignore");
-            if (!File.Exists(gitignoreFile))
+            lock (gitIgnoreLockObject)
             {
-                File.WriteAllText(gitignoreFile, requiredContents);
-            }
-            else if(!File.ReadAllText(gitignoreFile).Contains(Constants.SecretsJsonFileName))
-            {
-                File.AppendAllText(gitignoreFile, $"\n\n{requiredContents}");
+                if (!File.Exists(gitignoreFile))
+                {
+                    File.WriteAllText(gitignoreFile, requiredContents);
+                }
+                else if (!File.ReadAllText(gitignoreFile).Contains(Constants.SecretsJsonFileName))
+                {
+                    File.AppendAllText(gitignoreFile, $"\n\n{requiredContents}");
+                }
             }
 
 #endif

--- a/src/Mobile.BuildTools.Reference/Utils/ConfigHelper.shared.cs
+++ b/src/Mobile.BuildTools.Reference/Utils/ConfigHelper.shared.cs
@@ -13,6 +13,7 @@ namespace Mobile.BuildTools.Utils
     public static partial class ConfigHelper
     {
         private static readonly object lockObject = new object();
+        private static readonly object gitIgnoreLockObject = new object();
 
         public static string GetConfigurationPath(string searchDirectory, string slnDir = null)
         {

--- a/src/Mobile.BuildTools/Drawing/ImageBase.cs
+++ b/src/Mobile.BuildTools/Drawing/ImageBase.cs
@@ -25,9 +25,16 @@ namespace Mobile.BuildTools.Drawing
         public abstract void Draw(SKCanvas canvas, Context context);
 
         public static ImageBase Load(string filename)
-            => IsVector(filename)
+        {
+            if (!File.Exists(filename))
+            {
+                throw new FileNotFoundException("Could not load image file.", filename);
+            }
+
+            return IsVector(filename)
                 ? new VectorImage(filename)
                 : new Image(filename);
+        }
 
         private static bool IsVector(string filename) =>
             Path.GetExtension(filename)?.Equals(".svg", StringComparison.OrdinalIgnoreCase) ?? false;

--- a/tests/Mobile.BuildTools.Tests/Fixtures/Drawing/ImageBaseFixture.cs
+++ b/tests/Mobile.BuildTools.Tests/Fixtures/Drawing/ImageBaseFixture.cs
@@ -1,0 +1,19 @@
+﻿using System.IO;
+using Mobile.BuildTools.Drawing;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Mobile.BuildTools.Tests.Fixtures.Drawing
+{
+    public class ImageBaseFixture : FixtureBase
+    {
+        public ImageBaseFixture(ITestOutputHelper testOutputHelper)
+            : base(testOutputHelper)
+        {
+        }
+
+        [Fact]
+        public void LoadShouldThrowIfFileDoesNotExist() => 
+            Assert.Throws<FileNotFoundException>(() => ImageBase.Load($"{Path.GetRandomFileName()}.svg"));
+    }
+}

--- a/tests/Mobile.BuildTools.Tests/Fixtures/Generators/ImageCollectionGeneratorFixture.cs
+++ b/tests/Mobile.BuildTools.Tests/Fixtures/Generators/ImageCollectionGeneratorFixture.cs
@@ -171,6 +171,18 @@ namespace Mobile.BuildTools.Tests.Fixtures.Generators
             Assert.Equal("example", imageResource.Watermark?.SourceFile);
         }
 
+        [Fact]
+        public void ExecuteFindsValidPathForWatermarkSourceFile()
+        {
+            var config = GetConfiguration();
+            var generator = CreateGenerator(config, ImageDirectory, PlatformImageDirectory, DebugImageDirectory);
+
+            generator.Execute();
+
+            var outputImage = generator.Outputs.Last();
+            Assert.Equal("Templates\\Images\\Debug\\example.png", outputImage.Watermark.SourceFile);
+        }
+
         [Theory]
         [InlineData("dotnetbot")]
         [InlineData("platform")]


### PR DESCRIPTION
Watermark `sourceFile` paths are now correctly converted to a full file path during image asset collection ready for the image resizer to process appropriately.