### PR TITLE
The default seems to be BuildTools_ instead of Secret_

### DIFF
--- a/docs/continuous-integration/setup.md
+++ b/docs/continuous-integration/setup.md
@@ -9,4 +9,4 @@ Obviously if we checked in a json file with our secrets it would negate the enti
 | UWP | UWPSecret_ |
 | macOS | MacSecret_ |
 | Tizen | TizenSecret_ |
-| Default | Secret_ |
+| Default | BuildTools_ |


### PR DESCRIPTION
As mentioned in this issue #272 the default in the code is BuildTools_ and not Secret_ as in Mobile Builds tools version 1.x