### PR TITLE
Updated docs & samples for app.config

### DIFF
--- a/docs/config/app.config/in-code.md
+++ b/docs/config/app.config/in-code.md
@@ -10,12 +10,14 @@ var foo = ConfigurationManager.AppSettings["Foo"];
 
 Before using the ConfigurationManager you must initialize it.
 
+ConfigurationManager accepts a `bool` to enable runtime environments, this must be set to `true` if you want to use configuration transforms.
+
 AppDelegate.cs
 
 ```csharp
 public override bool FinishedLaunching(UIApplication app, NSDictionary options)
 {
-    ConfigurationManager.Init();
+    ConfigurationManager.Init(true);
     global::Xamarin.Forms.Forms.Init();
     LoadApplication(new App());
 
@@ -33,7 +35,7 @@ protected override void OnCreate(Bundle bundle)
 
     base.OnCreate(bundle);
 
-    ConfigurationManager.Init(this);
+    ConfigurationManager.Init(true, this);
 
     global::Xamarin.Forms.Forms.Init(this, bundle);
     LoadApplication(new App());

--- a/docs/config/app.config/transformations.md
+++ b/docs/config/app.config/transformations.md
@@ -21,7 +21,7 @@ A Transformation config may look like:
 <?xml version="1.0" encoding="utf-8" ?>
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
   <appSettings>
-    <add key="foo" value="transformed" xdt:Transform="Replace"/>
+    <add key="foo" value="transformed" xdt:Transform="Replace" xdt:Locator="Match(key)"/>
     <add key="Environment" value="Dev" xdt:Transform="Insert "/>
   </appSettings>
 </configuration>
@@ -43,11 +43,24 @@ After running the transform from either the automatic build task, at runtime or 
 </configuration>
 ```
 
+## XDT Transformations
+
 While the XDT namespace allows you to radically change your app.config. In most cases however you will only need to focus on the xdt:Transform attribute.
 
-- Replace
 - Insert
 - InsertBefore(XPath expression)
 - InsertAfter(XPath expression)
 - Remove
 - Remove All
+
+To find out more about the available transformations, see the [microsoft documentation](https://learn.microsoft.com/en-us/previous-versions/aspnet/dd465326(v=vs.110)).
+
+### Replace
+
+This transformation requires the `xdt:Locator` attribute to function correctly. In most cases this will be a simple match on the key attribute:
+
+```xml
+<add key="foo" value="transformed" xdt:Transform="Replace" xdt:Locator="Match(key)"/>
+```
+
+See the [documentation](https://learn.microsoft.com/en-us/previous-versions/aspnet/dd465326(v=vs.110)#locator-attribute-syntax) for all the ways in which the `xdt:Locator` attribute can be used.

--- a/samples/AppConfigSample/src/AppConfigSample.Android/AppConfigSample.Android.csproj
+++ b/samples/AppConfigSample/src/AppConfigSample.Android/AppConfigSample.Android.csproj
@@ -15,7 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v12.0</TargetFrameworkVersion>
     <AndroidEnableSGenConcurrent>true</AndroidEnableSGenConcurrent>
     <AndroidUseAapt2>true</AndroidUseAapt2>
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>

--- a/samples/AppConfigSample/src/AppConfigSample.Android/Assets/app.debug.config
+++ b/samples/AppConfigSample/src/AppConfigSample.Android/Assets/app.debug.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
   <appSettings>
-    <add key="foo" value="transformed" xdt:Transform="Replace"/>
+    <add key="foo" value="transformed" xdt:Transform="Replace" xdt:Locator="Match(key)"/>
     <add key="Environment" value="Debug" xdt:Transform="Insert "/>
   </appSettings>
 </configuration>

--- a/samples/AppConfigSample/src/AppConfigSample.Android/Assets/app.foo.config
+++ b/samples/AppConfigSample/src/AppConfigSample.Android/Assets/app.foo.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
   <appSettings>
-    <add key="foo" value="transformedFoo" xdt:Transform="Replace"/>
+    <add key="foo" value="transformedFoo" xdt:Transform="Replace" xdt:Locator="Match(key)"/>
     <add key="Environment" value="Foo" xdt:Transform="Insert "/>
   </appSettings>
 </configuration>

--- a/samples/AppConfigSample/src/AppConfigSample.Android/Assets/app.release.config
+++ b/samples/AppConfigSample/src/AppConfigSample.Android/Assets/app.release.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
   <appSettings>
-    <add key="foo" value="transformedRelease" xdt:Transform="Replace"/>
+    <add key="foo" value="transformedRelease" xdt:Transform="Replace" xdt:Locator="Match(key)"/>
     <add key="Environment" value="Release" xdt:Transform="Insert "/>
   </appSettings>
 </configuration>

--- a/samples/AppConfigSample/src/AppConfigSample.Android/SplashActivity.cs
+++ b/samples/AppConfigSample/src/AppConfigSample.Android/SplashActivity.cs
@@ -1,8 +1,7 @@
 ﻿using Android.App;
-using Android.OS;
-using Android.Support.V7.App;
 using Android.Content;
-using Android.Util;
+using Android.OS;
+using AndroidX.AppCompat.App;
 
 namespace AppConfigSample.Droid
 {

--- a/samples/AppConfigSample/src/AppConfigSample.iOS/Resources/app.debug.config
+++ b/samples/AppConfigSample/src/AppConfigSample.iOS/Resources/app.debug.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
   <appSettings>
-    <add key="foo" value="transformedDebug" xdt:Transform="Replace"/>
+    <add key="foo" value="transformedDebug" xdt:Transform="Replace" xdt:Locator="Match(key)"/>
     <add key="Environment" value="Debug" xdt:Transform="Insert "/>
   </appSettings>
 </configuration>

--- a/samples/AppConfigSample/src/AppConfigSample.iOS/Resources/app.foo.config
+++ b/samples/AppConfigSample/src/AppConfigSample.iOS/Resources/app.foo.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
   <appSettings>
-    <add key="foo" value="transformedFoo" xdt:Transform="Replace"/>
+    <add key="foo" value="transformedFoo" xdt:Transform="Replace" xdt:Locator="Match(key)"/>
     <add key="Environment" value="Foo" xdt:Transform="Insert "/>
   </appSettings>
 </configuration>

--- a/samples/AppConfigSample/src/AppConfigSample.iOS/Resources/app.release.config
+++ b/samples/AppConfigSample/src/AppConfigSample.iOS/Resources/app.release.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
   <appSettings>
-    <add key="foo" value="transformedRelease" xdt:Transform="Replace"/>
+    <add key="foo" value="transformedRelease" xdt:Transform="Replace" xdt:Locator="Match(key)"/>
     <add key="Environment" value="Release" xdt:Transform="Insert "/>
   </appSettings>
 </configuration>


### PR DESCRIPTION
This PR addresses issue #316

## Sample
- Updated the sample project for app.config to use the `xdt:Locator` attribute where any Replace transforms are performed. This will help prevent developers encountering some of the funky behaviour the `Microsoft.Web.XmlTransform` library performs when this attribute is omitted from the transformation xml.
- Bumped sample app android version target & fixed a dead namespace (it wasn't building locally so I thought I'd bundle those changes)

## Docs
- Updated the docs to reflect these changes, with links to the Microsoft docs where relevant.
- Updated the `ConfigurationManager` init code to mention & explain the `enableRuntimeEnvironments` flag
