### PR TITLE
Adding Microsoft.Extensions.Configuration Provider

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,8 @@
     <PackageVersion Include="Microsoft.Build" Version="17.0.0" />
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.2.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageVersion Include="Newtonsoft.Json.Schema" Version="3.0.14" />
     <PackageVersion Include="NuGet.Build.Packaging" Version="0.2.5-dev.10" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,8 @@
     <PackageVersion Include="Microsoft.Build" Version="17.0.0" />
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.2.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageVersion Include="Newtonsoft.Json.Schema" Version="3.0.14" />

--- a/src/Mobile.BuildTools.Configuration/AppConfigElement.cs
+++ b/src/Mobile.BuildTools.Configuration/AppConfigElement.cs
@@ -1,13 +1,12 @@
-﻿namespace Mobile.BuildTools.Configuration
+﻿namespace Mobile.BuildTools.Configuration;
+
+internal static class AppConfigElement
 {
-    internal static class AppConfigElement
-    {
-        public const string AppSettings = "appSettings";
-        public const string ConnectionString = "connectionString";
-        public const string ConnectionStrings = "connectionStrings";
-        public const string Key = "key";
-        public const string Name = "name";
-        public const string ProviderName = "providerName";
-        public const string Value = "value";
-    }
+    public const string AppSettings = "appSettings";
+    public const string ConnectionString = "connectionString";
+    public const string ConnectionStrings = "connectionStrings";
+    public const string Key = "key";
+    public const string Name = "name";
+    public const string ProviderName = "providerName";
+    public const string Value = "value";
 }

--- a/src/Mobile.BuildTools.Configuration/AppConfigProvider.cs
+++ b/src/Mobile.BuildTools.Configuration/AppConfigProvider.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Extensions.Configuration;
+
+namespace Mobile.BuildTools.Configuration;
+
+internal class AppConfigProvider : ConfigurationProvider
+{
+    private IConfigurationManager _manager { get; }
+    public AppConfigProvider(IConfigurationManager manager)
+    {
+        _manager = manager;
+        if (_manager.Environments.Count > 1)
+            _manager.SettingsChanged += (s, e) =>
+            {
+                Load();
+                OnReload();
+            };
+    }
+
+    public override void Load()
+    {
+        Data = _manager.ToData();
+    }
+}

--- a/src/Mobile.BuildTools.Configuration/AppConfigProvider.cs
+++ b/src/Mobile.BuildTools.Configuration/AppConfigProvider.cs
@@ -1,13 +1,19 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using System.Diagnostics;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Primitives;
 
+#nullable enable
 namespace Mobile.BuildTools.Configuration;
 
-internal class AppConfigProvider : ConfigurationProvider
+internal class AppConfigProvider : IConfigurationProvider
 {
     private IConfigurationManager _manager { get; }
+    private ConfigurationReloadToken _reloadToken = new ConfigurationReloadToken();
+
     public AppConfigProvider(IConfigurationManager manager)
     {
         _manager = manager;
+        Data = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
         if (_manager.Environments.Count > 1)
             _manager.SettingsChanged += (s, e) =>
             {
@@ -16,8 +22,100 @@ internal class AppConfigProvider : ConfigurationProvider
             };
     }
 
-    public override void Load()
+    private IDictionary<string, string?> Data { get; set; }
+
+    /// <summary>
+    /// Attempts to find a value with the given key, returns true if one is found, false otherwise.
+    /// </summary>
+    /// <param name="key">The key to lookup.</param>
+    /// <param name="value">The value found at key if one is found.</param>
+    /// <returns>True if key has a value, false otherwise.</returns>
+    public virtual bool TryGet(string key, out string? value)
+        => Data.TryGetValue(key, out value);
+
+    /// <summary>
+    /// Sets a value for a given key.
+    /// </summary>
+    /// <param name="key">The configuration key to set.</param>
+    /// <param name="value">The value to set.</param>
+    public virtual void Set(string key, string? value)
+    {
+        // TODO: Evaluate if this should throw an exception instead
+    }
+
+    /// <summary>
+    /// Returns a <see cref="IChangeToken"/> that can be used to listen when this provider is reloaded.
+    /// </summary>
+    /// <returns>The <see cref="IChangeToken"/>.</returns>
+    public IChangeToken GetReloadToken()
+    {
+        return _reloadToken;
+    }
+
+    public void Load()
     {
         Data = _manager.ToData();
     }
+
+    /// <summary>
+    /// Returns the list of keys that this provider has.
+    /// </summary>
+    /// <param name="earlierKeys">The earlier keys that other providers contain.</param>
+    /// <param name="parentPath">The path for the parent IConfiguration.</param>
+    /// <returns>The list of keys for this provider.</returns>
+    public virtual IEnumerable<string> GetChildKeys(
+        IEnumerable<string> earlierKeys,
+        string? parentPath)
+    {
+        var results = new List<string>();
+
+        if (parentPath is null)
+        {
+            foreach (KeyValuePair<string, string?> kv in Data)
+            {
+                results.Add(Segment(kv.Key, 0));
+            }
+        }
+        else
+        {
+            Debug.Assert(ConfigurationPath.KeyDelimiter == ":");
+
+            foreach (KeyValuePair<string, string?> kv in Data)
+            {
+                if (kv.Key.Length > parentPath.Length &&
+                    kv.Key.StartsWith(parentPath, StringComparison.OrdinalIgnoreCase) &&
+                    kv.Key[parentPath.Length] == ':')
+                {
+                    results.Add(Segment(kv.Key, parentPath.Length + 1));
+                }
+            }
+        }
+
+        results.AddRange(earlierKeys);
+
+        results.Sort(ConfigurationKeyComparer.Comparison);
+
+        return results;
+    }
+
+    private static string Segment(string key, int prefixLength)
+    {
+        var indexOf = key.IndexOf(ConfigurationPath.KeyDelimiter, prefixLength, StringComparison.OrdinalIgnoreCase);
+        return indexOf < 0 ? key.Substring(prefixLength) : key.Substring(prefixLength, indexOf - prefixLength);
+    }
+
+    /// <summary>
+    /// Triggers the reload change token and creates a new one.
+    /// </summary>
+    protected void OnReload()
+    {
+        var previousToken = Interlocked.Exchange(ref _reloadToken, new ConfigurationReloadToken());
+        previousToken.OnReload();
+    }
+
+    /// <summary>
+    /// Generates a string representing this provider name and relevant details.
+    /// </summary>
+    /// <returns> The configuration name. </returns>
+    public override string ToString() => $"{GetType().Name}";
 }

--- a/src/Mobile.BuildTools.Configuration/AppConfigSource.cs
+++ b/src/Mobile.BuildTools.Configuration/AppConfigSource.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.Extensions.Configuration;
+
+namespace Mobile.BuildTools.Configuration;
+
+internal class AppConfigSource : IConfigurationSource
+{
+    private IConfigurationManager _manager { get; }
+
+    public AppConfigSource(IConfigurationManager manager)
+    {
+        _manager = manager;
+    }
+
+    public IConfigurationProvider Build(IConfigurationBuilder builder)
+    {
+        return new AppConfigProvider(_manager);
+    }
+}

--- a/src/Mobile.BuildTools.Configuration/BuildToolsConfigurationExtensions.cs
+++ b/src/Mobile.BuildTools.Configuration/BuildToolsConfigurationExtensions.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.Extensions.Configuration;
+
+namespace Mobile.BuildTools.Configuration;
+
+public static class BuildToolsConfigurationExtensions
+{
+    public static IConfigurationBuilder AddAppConfig(this IConfigurationBuilder builder, bool enableRuntimeEnvironments)
+    {
+        ConfigurationManager.Init(enableRuntimeEnvironments);
+        return AddAppConfig(builder, ConfigurationManager.Current);
+    }
+
+#if ANDROID
+    public static IConfigurationBuilder AddAppConfig(this IConfigurationBuilder builder, bool enableRuntimeEnvironments, Android.Content.Context context)
+    {
+        ConfigurationManager.Init(enableRuntimeEnvironments, context);
+        return AddAppConfig(builder, ConfigurationManager.Current);
+    }
+#endif
+
+    public static IConfigurationBuilder AddAppConfig(this IConfigurationBuilder builder, IConfigurationManager manager)
+    {
+        return builder.Add(new AppConfigSource(manager));
+    }
+
+    internal static IDictionary<string, string> ToData(this IConfigurationManager manager)
+    {
+        var data = new Dictionary<string, string>();
+        manager.AppSettings.ToList().ForEach(x => data.Add(x.Key, x.Value));
+        manager.ConnectionStrings.ToList().ForEach(x => data.Add($"ConnectionStrings:{x.Name}", x.ConnectionString));
+
+        return data;
+    }
+}

--- a/src/Mobile.BuildTools.Configuration/BuildToolsConfigurationExtensions.cs
+++ b/src/Mobile.BuildTools.Configuration/BuildToolsConfigurationExtensions.cs
@@ -1,24 +1,40 @@
 ﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace Mobile.BuildTools.Configuration;
 
 public static class BuildToolsConfigurationExtensions
 {
-    public static IConfigurationBuilder AddAppConfig(this IConfigurationBuilder builder, bool enableRuntimeEnvironments)
+    public static IHostBuilder AddBuildToolsConfiguration(this IHostBuilder host, bool enableRuntimeEnvironments)
     {
-        ConfigurationManager.Init(enableRuntimeEnvironments);
-        return AddAppConfig(builder, ConfigurationManager.Current);
+        var manager = ConfigurationManager.Init(enableRuntimeEnvironments);
+        return host.ConfigureHostConfiguration(c => c.AddBuildToolsConfiguration(manager))
+            .ConfigureServices((_, s) => s.AddSingleton<IConfigurationManager>(manager));
+    }
+
+    public static IConfigurationBuilder AddBuildToolsConfiguration(this IConfigurationBuilder builder, bool enableRuntimeEnvironments)
+    {
+        var manager = ConfigurationManager.Init(enableRuntimeEnvironments);
+        return AddBuildToolsConfiguration(builder, manager);
     }
 
 #if ANDROID
-    public static IConfigurationBuilder AddAppConfig(this IConfigurationBuilder builder, bool enableRuntimeEnvironments, Android.Content.Context context)
+    public static IHostBuilder AddBuildToolsConfiguration(this IHostBuilder host, bool enableRuntimeEnvironments, Android.Content.Context context)
     {
-        ConfigurationManager.Init(enableRuntimeEnvironments, context);
-        return AddAppConfig(builder, ConfigurationManager.Current);
+        var manager = ConfigurationManager.Init(enableRuntimeEnvironments, context);
+        return host.ConfigureHostConfiguration(c => c.AddBuildToolsConfiguration(manager))
+            .ConfigureServices((_, s) => s.AddSingleton<IConfigurationManager>(manager));
+    }
+
+    public static IConfigurationBuilder AddBuildToolsConfiguration(this IConfigurationBuilder builder, bool enableRuntimeEnvironments, Android.Content.Context context)
+    {
+        var manager = ConfigurationManager.Init(enableRuntimeEnvironments, context);
+        return AddBuildToolsConfiguration(builder, manager);
     }
 #endif
 
-    public static IConfigurationBuilder AddAppConfig(this IConfigurationBuilder builder, IConfigurationManager manager)
+    public static IConfigurationBuilder AddBuildToolsConfiguration(this IConfigurationBuilder builder, IConfigurationManager manager)
     {
         return builder.Add(new AppConfigSource(manager));
     }

--- a/src/Mobile.BuildTools.Configuration/ChangeCallbackRegistrar.cs
+++ b/src/Mobile.BuildTools.Configuration/ChangeCallbackRegistrar.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.Extensions.Primitives;
+
+#nullable enable
+namespace Mobile.BuildTools.Configuration;
+
+internal static class ChangeCallbackRegistrar
+{
+    /// <summary>
+    /// Registers for a callback that will be invoked when the entry has changed. <see cref="IChangeToken.HasChanged"/>
+    /// MUST be set before the callback is invoked.
+    /// </summary>
+    /// <param name="callback">The callback to invoke.</param>
+    /// <param name="state">State to be passed into the callback.</param>
+    /// <param name="token">The <see cref="CancellationToken"/> to invoke the callback with.</param>
+    /// <param name="onFailure">The action to execute when an <see cref="ObjectDisposedException"/> is thrown. Should be used to set the IChangeToken's ActiveChangeCallbacks property to false.</param>
+    /// <param name="onFailureState">The state to be passed into the <paramref name="onFailure"/> action.</param>
+    /// <returns>The <see cref="CancellationToken"/> registration.</returns>
+    internal static IDisposable UnsafeRegisterChangeCallback<T>(Action<object?> callback, object? state, CancellationToken token, Action<T> onFailure, T onFailureState)
+    {
+        try
+        {
+            return token.UnsafeRegister(callback, state);
+        }
+        catch (ObjectDisposedException)
+        {
+            onFailure(onFailureState);
+        }
+
+        return EmptyDisposable.Instance;
+    }
+}
+
+

--- a/src/Mobile.BuildTools.Configuration/ConfigurationKeyComparer.cs
+++ b/src/Mobile.BuildTools.Configuration/ConfigurationKeyComparer.cs
@@ -1,0 +1,90 @@
+﻿#nullable enable
+namespace Mobile.BuildTools.Configuration;
+
+/// <summary>
+/// IComparer implementation used to order configuration keys.
+/// </summary>
+public class ConfigurationKeyComparer : IComparer<string>
+{
+    private const char KeyDelimiter = ':';
+
+    /// <summary>
+    /// The default instance.
+    /// </summary>
+    public static ConfigurationKeyComparer Instance { get; } = new ConfigurationKeyComparer();
+
+    /// <summary>A comparer delegate with the default instance.</summary>
+    internal static Comparison<string> Comparison { get; } = Instance.Compare;
+
+    /// <summary>
+    /// Compares two strings.
+    /// </summary>
+    /// <param name="x">First string.</param>
+    /// <param name="y">Second string.</param>
+    /// <returns>Less than 0 if x is less than y, 0 if x is equal to y and greater than 0 if x is greater than y.</returns>
+    public int Compare(string? x, string? y)
+    {
+        var xSpan = x.AsSpan();
+        var ySpan = y.AsSpan();
+
+        xSpan = SkipAheadOnDelimiter(xSpan);
+        ySpan = SkipAheadOnDelimiter(ySpan);
+
+        // Compare each part until we get two parts that are not equal
+        while (!xSpan.IsEmpty && !ySpan.IsEmpty)
+        {
+            var xDelimiterIndex = xSpan.IndexOf(KeyDelimiter);
+            var yDelimiterIndex = ySpan.IndexOf(KeyDelimiter);
+
+            var compareResult = Compare(
+                xDelimiterIndex == -1 ? xSpan : xSpan.Slice(0, xDelimiterIndex),
+                yDelimiterIndex == -1 ? ySpan : ySpan.Slice(0, yDelimiterIndex));
+
+            if (compareResult != 0)
+            {
+                return compareResult;
+            }
+
+            xSpan = xDelimiterIndex == -1 ? default :
+                SkipAheadOnDelimiter(xSpan.Slice(xDelimiterIndex + 1));
+            ySpan = yDelimiterIndex == -1 ? default :
+                SkipAheadOnDelimiter(ySpan.Slice(yDelimiterIndex + 1));
+        }
+
+        return xSpan.IsEmpty ? (ySpan.IsEmpty ? 0 : -1) : 1;
+
+        static ReadOnlySpan<char> SkipAheadOnDelimiter(ReadOnlySpan<char> a)
+        {
+            while (!a.IsEmpty && a[0] == KeyDelimiter)
+            {
+                a = a.Slice(1);
+            }
+            return a;
+        }
+
+        static int Compare(ReadOnlySpan<char> a, ReadOnlySpan<char> b)
+        {
+            var aIsInt = int.TryParse(a, out var value1);
+            var bIsInt = int.TryParse(b, out var value2);
+            int result;
+
+            if (!aIsInt && !bIsInt)
+            {
+                // Both are strings
+                result = a.CompareTo(b, StringComparison.OrdinalIgnoreCase);
+            }
+            else if (aIsInt && bIsInt)
+            {
+                // Both are int
+                result = value1 - value2;
+            }
+            else
+            {
+                // Only one of them is int
+                result = aIsInt ? -1 : 1;
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/Mobile.BuildTools.Configuration/ConfigurationReloadToken.cs
+++ b/src/Mobile.BuildTools.Configuration/ConfigurationReloadToken.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.Extensions.Primitives;
+
+#nullable enable
+namespace Mobile.BuildTools.Configuration;
+
+/// <summary>
+/// Implements <see cref="IChangeToken"/>
+/// </summary>
+internal class ConfigurationReloadToken : IChangeToken
+{
+    private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+
+    /// <summary>
+    /// Indicates if this token will proactively raise callbacks. Callbacks are still guaranteed to be invoked, eventually.
+    /// </summary>
+    /// <returns>True if the token will proactively raise callbacks.</returns>
+    public bool ActiveChangeCallbacks { get; private set; } = true;
+
+    /// <summary>
+    /// Gets a value that indicates if a change has occurred.
+    /// </summary>
+    /// <returns>True if a change has occurred.</returns>
+    public bool HasChanged => _cts.IsCancellationRequested;
+
+    /// <summary>
+    /// Registers for a callback that will be invoked when the entry has changed. <see cref="IChangeToken.HasChanged"/>
+    /// MUST be set before the callback is invoked.
+    /// </summary>
+    /// <param name="callback">The callback to invoke.</param>
+    /// <param name="state">State to be passed into the callback.</param>
+    /// <returns>The <see cref="CancellationToken"/> registration.</returns>
+    public IDisposable RegisterChangeCallback(Action<object?> callback, object? state) =>
+        ChangeCallbackRegistrar.UnsafeRegisterChangeCallback(
+            callback,
+            state,
+            _cts.Token,
+            static s => s.ActiveChangeCallbacks = false, // Reset the flag to indicate to future callers that this wouldn't work.
+            this);
+
+    /// <summary>
+    /// Used to trigger the change token when a reload occurs.
+    /// </summary>
+    public void OnReload() => _cts.Cancel();
+}

--- a/src/Mobile.BuildTools.Configuration/EmptyDisposable.cs
+++ b/src/Mobile.BuildTools.Configuration/EmptyDisposable.cs
@@ -1,0 +1,14 @@
+﻿namespace Mobile.BuildTools.Configuration;
+
+internal sealed class EmptyDisposable : IDisposable
+{
+    public static EmptyDisposable Instance { get; } = new EmptyDisposable();
+
+    private EmptyDisposable()
+    {
+    }
+
+    public void Dispose()
+    {
+    }
+}

--- a/src/Mobile.BuildTools.Configuration/IConfigurationManager.cs
+++ b/src/Mobile.BuildTools.Configuration/IConfigurationManager.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace Mobile.BuildTools.Configuration
+﻿namespace Mobile.BuildTools.Configuration
 {
     public interface IConfigurationManager
     {
@@ -9,6 +7,7 @@ namespace Mobile.BuildTools.Configuration
 
         bool EnvironmentExists(string name);
         IReadOnlyList<string> Environments { get; }
+        event EventHandler SettingsChanged;
         void Reset();
         void Transform(string name);
     }

--- a/src/Mobile.BuildTools.Configuration/Mobile.BuildTools.Configuration.csproj
+++ b/src/Mobile.BuildTools.Configuration/Mobile.BuildTools.Configuration.csproj
@@ -14,6 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Remove="Platform/**/*.cs" />
     <None Include="Platform/**/*.cs" />
   </ItemGroup>

--- a/src/Mobile.BuildTools.Configuration/Mobile.BuildTools.Configuration.csproj
+++ b/src/Mobile.BuildTools.Configuration/Mobile.BuildTools.Configuration.csproj
@@ -14,7 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Mobile.BuildTools.Configuration.Tests/ConfigurationManagerTests.cs
+++ b/tests/Mobile.BuildTools.Configuration.Tests/ConfigurationManagerTests.cs
@@ -7,16 +7,16 @@ namespace Mobile.BuildTools.Configuration.Tests
         [Fact]
         public void ShouldGetValuesForAppSettings()
         {
-            ConfigurationManager.Init();
+            var manager = ConfigurationManager.Init();
 
             // setup
             const string expectedFoo = "my foo";
             const string expectedBar = "my bar";
 
             // assert
-            Assert.Equal(expectedFoo, ConfigurationManager.AppSettings["foo"]);
-            Assert.Equal(expectedBar, ConfigurationManager.AppSettings["bar"]);
-            Assert.Equal(2, ConfigurationManager.AppSettings.Count);
+            Assert.Equal(expectedFoo, manager.AppSettings["foo"]);
+            Assert.Equal(expectedBar, manager.AppSettings["bar"]);
+            Assert.Equal(4, manager.AppSettings.Count);
         }
 
         [Fact]
@@ -63,27 +63,27 @@ namespace Mobile.BuildTools.Configuration.Tests
         [Fact]
         public void ResetTransformsBackToDefault()
         {
-            ConfigurationManager.Init(true);
+            var manager = ConfigurationManager.Init(true);
 
-            Assert.Equal("my foo", ConfigurationManager.AppSettings["foo"]);
-            ConfigurationManager.Transform("foo");
-            Assert.Equal("transformed", ConfigurationManager.AppSettings["foo"]);
-            ConfigurationManager.Reset();
-            Assert.Equal("my foo", ConfigurationManager.AppSettings["foo"]);
+            Assert.Equal("my foo", manager.AppSettings["foo"]);
+            manager.Transform("foo");
+            Assert.Equal("transformed", manager.AppSettings["foo"]);
+            manager.Reset();
+            Assert.Equal("my foo", manager.AppSettings["foo"]);
         }
 
         [Fact]
         public void SingleEnvironmentListed()
         {
-            ConfigurationManager.Init(true);
-            Assert.Single(ConfigurationManager.Environments);
+            var manager = ConfigurationManager.Init(true);
+            Assert.Single(manager.Environments);
         }
 
         [Fact]
         public void NoEnvironmentListedIfNotEnabled()
         {
-            ConfigurationManager.Init();
-            Assert.Empty(ConfigurationManager.Environments);
+            var manager =ConfigurationManager.Init();
+            Assert.Empty(manager.Environments);
         }
 
         [Theory]
@@ -93,36 +93,36 @@ namespace Mobile.BuildTools.Configuration.Tests
         [InlineData("app.Foo.config")]
         public void EnvironmentExists(string environment)
         {
-            ConfigurationManager.Init(true);
-            Assert.True(ConfigurationManager.EnvironmentExists(environment));
+            var manager = ConfigurationManager.Init(true);
+            Assert.True(manager.EnvironmentExists(environment));
         }
 
         [Fact]
         public void EnvironmentDoesNotExist()
         {
-            ConfigurationManager.Init(true);
-            Assert.False(ConfigurationManager.EnvironmentExists("notValid"));
+            var manager = ConfigurationManager.Init(true);
+            Assert.False(manager.EnvironmentExists("notValid"));
         }
 
         [Fact]
         public void EnvironmentDoesNotExistWhenEnvironmentsNotEnabled()
         {
-            ConfigurationManager.Init();
-            Assert.False(ConfigurationManager.EnvironmentExists("foo"));
+            var manager = ConfigurationManager.Init();
+            Assert.False(manager.EnvironmentExists("foo"));
         }
 
         [Fact]
         public void AppConfigTransformsForEnvironment()
         {
-            ConfigurationManager.Init(true);
-            Assert.Equal("my foo", ConfigurationManager.AppSettings["foo"]);
-            Assert.DoesNotContain("Environment", ConfigurationManager.AppSettings.AllKeys);
-            ConfigurationManager.Transform("foo");
+            var manager = ConfigurationManager.Init(true);
+            Assert.Equal("my foo", manager.AppSettings["foo"]);
+            Assert.DoesNotContain("Environment", manager.AppSettings.AllKeys);
+            manager.Transform("foo");
 
-            Assert.Equal(3, ConfigurationManager.AppSettings.Count);
-            Assert.Contains("Environment", ConfigurationManager.AppSettings.AllKeys);
-            Assert.Equal("Debug", ConfigurationManager.AppSettings["Environment"]);
-            Assert.Equal("transformed", ConfigurationManager.AppSettings["foo"]);
+            Assert.Equal(5, manager.AppSettings.Count);
+            Assert.Contains("Environment", manager.AppSettings.AllKeys);
+            Assert.Equal("Debug", manager.AppSettings["Environment"]);
+            Assert.Equal("transformed", manager.AppSettings["foo"]);
         }
     }
 }

--- a/tests/Mobile.BuildTools.Configuration.Tests/MicrosoftExtensionsFixture.cs
+++ b/tests/Mobile.BuildTools.Configuration.Tests/MicrosoftExtensionsFixture.cs
@@ -13,7 +13,7 @@ public class MicrosoftExtensionsFixture
     public void LoadsConfiguration(string key, string expectedValue)
     {
         var host = new HostBuilder()
-            .ConfigureHostConfiguration(configuration => configuration.AddAppConfig(false))
+            .ConfigureHostConfiguration(configuration => configuration.AddBuildToolsConfiguration(false))
             .Build();
 
         var configuration = host.Services.GetService<IConfiguration>();
@@ -27,7 +27,7 @@ public class MicrosoftExtensionsFixture
     public void WorksWithSection()
     {
         var host = new HostBuilder()
-            .ConfigureHostConfiguration(configuration => configuration.AddAppConfig(false))
+            .ConfigureHostConfiguration(configuration => configuration.AddBuildToolsConfiguration(false))
             .Build();
 
         var configuration = host.Services.GetService<IConfiguration>();
@@ -42,7 +42,7 @@ public class MicrosoftExtensionsFixture
     public void LoadsConnectionStrings()
     {
         var host = new HostBuilder()
-           .ConfigureHostConfiguration(configuration => configuration.AddAppConfig(false))
+           .ConfigureHostConfiguration(configuration => configuration.AddBuildToolsConfiguration(false))
            .Build();
 
         var configuration = host.Services.GetService<IConfiguration>();

--- a/tests/Mobile.BuildTools.Configuration.Tests/MicrosoftExtensionsFixture.cs
+++ b/tests/Mobile.BuildTools.Configuration.Tests/MicrosoftExtensionsFixture.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Xunit;
@@ -36,6 +36,19 @@ public class MicrosoftExtensionsFixture
         var oauth = configuration.GetSection("OAuth").Get<OAuth>();
         Assert.Equal("testClientId", oauth.ClientId);
         Assert.Equal("testClientSecret", oauth.ClientSecret);
+    }
+
+    [Fact]
+    public void LoadsConnectionStrings()
+    {
+        var host = new HostBuilder()
+           .ConfigureHostConfiguration(configuration => configuration.AddAppConfig(false))
+           .Build();
+
+        var configuration = host.Services.GetService<IConfiguration>();
+        Assert.NotNull(configuration);
+
+        Assert.Equal("my connection string", configuration.GetConnectionString("test"));
     }
 
     private record OAuth(string ClientId, string ClientSecret);

--- a/tests/Mobile.BuildTools.Configuration.Tests/MicrosoftExtensionsFixture.cs
+++ b/tests/Mobile.BuildTools.Configuration.Tests/MicrosoftExtensionsFixture.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Mobile.BuildTools.Configuration.Tests;
+
+public class MicrosoftExtensionsFixture
+{
+    [Theory]
+    [InlineData("foo", "my foo")]
+    [InlineData("bar", "my bar")]
+    public void LoadsConfiguration(string key, string expectedValue)
+    {
+        var host = new HostBuilder()
+            .ConfigureHostConfiguration(configuration => configuration.AddAppConfig(false))
+            .Build();
+
+        var configuration = host.Services.GetService<IConfiguration>();
+        Assert.NotNull(configuration);
+
+        Assert.Equal(expectedValue, configuration.GetValue<string>(key));
+
+    }
+
+    [Fact]
+    public void WorksWithSection()
+    {
+        var host = new HostBuilder()
+            .ConfigureHostConfiguration(configuration => configuration.AddAppConfig(false))
+            .Build();
+
+        var configuration = host.Services.GetService<IConfiguration>();
+        Assert.NotNull(configuration);
+
+        var oauth = configuration.GetSection("OAuth").Get<OAuth>();
+        Assert.Equal("testClientId", oauth.ClientId);
+        Assert.Equal("testClientSecret", oauth.ClientSecret);
+    }
+
+    private record OAuth(string ClientId, string ClientSecret);
+}

--- a/tests/Mobile.BuildTools.Configuration.Tests/Mobile.BuildTools.Configuration.Tests.csproj
+++ b/tests/Mobile.BuildTools.Configuration.Tests/Mobile.BuildTools.Configuration.Tests.csproj
@@ -10,6 +10,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/tests/Mobile.BuildTools.Configuration.Tests/app.config
+++ b/tests/Mobile.BuildTools.Configuration.Tests/app.config
@@ -3,6 +3,8 @@
   <appSettings>
     <add key="foo" value="my foo" />
     <add key="bar" value="my bar" />
+    <add key="OAuth:ClientId" value="testClientId"/>
+    <add key="OAuth:ClientSecret" value="testClientSecret"/>
   </appSettings>
   <connectionStrings>
     <add name="test" providerName="my provider" connectionString="my connection string"/>


### PR DESCRIPTION
# Description

This adds a dependency on Microsoft.Extensions.Configuration and adds a ConfigurationSource using the Mobile.BuildTools IConfigurationManager. This means that whether relying on an updated app.config as part of your project or changing environments at runtime you can get the updated configuration settings using the mechanisms you are used to with Microsoft.Extensions.Configuration.