### PR TITLE
Minor tweaks to improve nugetizability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ obj
 .mfractor
 *.userprefs
 *.binlog
-*.csproj.user
+*.user
 
 
 Artifacts/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -42,10 +42,7 @@
 
   <ItemGroup>
     <SourceRoot Include="$(MSBuildThisFileDirectory)/"/>
-    <PackageReference Include="Nerdbank.GitVersioning">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="MinVer" PrivateAssets="all" />
   </ItemGroup>
 
   <Choose>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,4 +15,6 @@
           Condition="Exists('$(NuGetPackageRoot)$(PackageId.ToLowerInvariant())') And '$(OS)' != 'Windows_NT'" />
   </Target>
 
+  <Import Project="Directory.Build.targets.user" Condition="Exists('Directory.Build.targets.user')"/>
+
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -46,6 +46,6 @@
     <PackageVersion Include="Xamarin.UITest" Version="3.0.14" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.4.255" />
+    <PackageVersion Include="MinVer" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/src/Mobile.BuildTools.Configuration/Mobile.BuildTools.Configuration.csproj
+++ b/src/Mobile.BuildTools.Configuration/Mobile.BuildTools.Configuration.csproj
@@ -10,6 +10,7 @@
     <Description>Provides a Cross Platform implementation of the ConfigurationManager. This allows you to load an app.config from any platform head as well as load custom configs at runtime or transform your configuration at runtime.</Description>
     <LangVersion>Latest</LangVersion>
     <PackageTags>mobile;configuration;appconfig;appconfig.xml</PackageTags>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Add this targets file alongside `Directory.Build.targets` named `Directory.Build.targets.user` (which will now be ignored in commits):

```xml
<Project>

  <PropertyGroup>
    <RestoreSources>https://pkg.kzu.io/index.json;https://api.nuget.org/v3/index.json</RestoreSources>
  </PropertyGroup>

  <ItemGroup>
    <PackageVersion Update="NuGetizer" Version="42.42.42-main.807" />
  </ItemGroup>

</Project>
```

This adds the CI nugetizer package feed and the latest build from main, which contains the fix for platform-suffixed target frameworks: https://github.com/devlooped/nugetizer/pull/306