### PR TITLE
Fix AppManifests processing

### DIFF
--- a/.github/actions/msbuild-build/action.yml
+++ b/.github/actions/msbuild-build/action.yml
@@ -109,9 +109,9 @@ runs:
           --logger ${{ inputs.dotnet-test-logger }} `
           --blame-crash `
           --collect:"XPlat Code Coverage" `
+          --no-build `
           -- `
-          DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover `
-          --no-build
+          DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
 
     - name: Sign NuGet Packages
       if: ${{ inputs.code-sign == 'true' }}

--- a/.github/actions/msbuild-build/action.yml
+++ b/.github/actions/msbuild-build/action.yml
@@ -1,0 +1,143 @@
+name: MSBuild Build
+description: Build/test/package a .NET solution with a loose SDK train and stable-SDK selection.
+
+inputs:
+  name:
+    description: The display name for the build.
+    required: true
+  solution-path:
+    description: The solution or project path to build.
+    required: true
+  dotnet-version:
+    description: The .NET SDK train to install through setup-dotnet.
+    default: 8.0.x
+  dotnet-sdk-glob:
+    description: The installed SDK glob to select for MSBuild SDK resolution.
+    default: 8.0.*
+  install-workload:
+    description: Optional workloads to install with the selected SDK.
+    default: ''
+  vs-version:
+    description: Visual Studio version for setup-msbuild.
+    required: false
+    default: ''
+  vs-prerelease:
+    description: Whether setup-msbuild should allow prerelease Visual Studio.
+    default: 'false'
+  build-configuration:
+    description: Build configuration.
+    default: Release
+  build-args:
+    description: Additional MSBuild arguments.
+    default: ''
+  run-tests:
+    description: Whether to run solution tests after build.
+    default: 'true'
+  dotnet-test-logger:
+    description: dotnet test logger.
+    default: GitHubActions
+  artifacts-path:
+    description: Path to build artifacts.
+    default: ./Artifacts/
+  artifact-name:
+    description: Uploaded artifact name. Empty disables upload.
+    default: NuGet
+  code-sign:
+    description: Whether to sign NuGet packages.
+    default: 'false'
+  codeSignTimestampUrl:
+    description: Timestamp URL for package signing.
+    default: ''
+  codeSignKeyVault:
+    description: Key Vault URL/name for package signing.
+    default: ''
+  codeSignClientId:
+    description: Client id for package signing.
+    default: ''
+  codeSignTenantId:
+    description: Tenant id for package signing.
+    default: ''
+  codeSignClientSecret:
+    description: Client secret for package signing.
+    default: ''
+  codeSignCertificate:
+    description: Certificate name for package signing.
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Setup .NET ${{ inputs.dotnet-version }}
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: ${{ inputs.dotnet-version }}
+
+    - name: Select .NET SDK for MSBuild
+      shell: pwsh
+      run: |
+        $sdkVersion = dotnet --list-sdks |
+          Where-Object { $_ -like '${{ inputs.dotnet-sdk-glob }}' } |
+          Select-Object -Last 1 |
+          ForEach-Object { ($_ -split ' ')[0] }
+        if (-not $sdkVersion) {
+          throw "No installed .NET SDK matched '${{ inputs.dotnet-sdk-glob }}'."
+        }
+        "DOTNET_SDK_VERSION=$sdkVersion" >> $env:GITHUB_ENV
+        Write-Host "Using .NET SDK $sdkVersion."
+
+    - name: Install .NET Workload
+      if: ${{ inputs.install-workload != '' }}
+      shell: pwsh
+      run: |
+        dotnet exec "$env:DOTNET_ROOT\sdk\$env:DOTNET_SDK_VERSION\dotnet.dll" workload install ${{ inputs.install-workload }}
+
+    - name: Download Latest NuGet.exe
+      shell: pwsh
+      run: curl -L -o nuget.exe https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+
+    - name: Build Packages
+      shell: pwsh
+      run: |
+        dotnet exec "$env:DOTNET_ROOT\sdk\$env:DOTNET_SDK_VERSION\MSBuild.dll" ${{ inputs.solution-path }} /r /p:Configuration=${{ inputs.build-configuration }} ${{ inputs.build-args }}
+
+    - name: Run Tests
+      if: ${{ inputs.run-tests == 'true' }}
+      shell: pwsh
+      run: |
+        dotnet exec "$env:DOTNET_ROOT\sdk\$env:DOTNET_SDK_VERSION\dotnet.dll" test ${{ inputs.solution-path }} `
+          --configuration ${{ inputs.build-configuration }} `
+          --logger ${{ inputs.dotnet-test-logger }} `
+          --blame-crash `
+          --collect:"XPlat Code Coverage" `
+          -- `
+          DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover `
+          --no-build
+
+    - name: Sign NuGet Packages
+      if: ${{ inputs.code-sign == 'true' }}
+      shell: pwsh
+      working-directory: ${{ inputs.artifacts-path }}
+      run: |
+        dotnet tool install --global NuGetKeyVaultSignTool
+        $timestampUrl = '${{ inputs.codeSignTimestampUrl }}'
+        if ($timestampUrl -eq '') {
+          $timestampUrl = 'http://timestamp.digicert.com'
+        }
+        Get-ChildItem -Recurse | Where-Object { $_.Name.EndsWith('.nupkg') -or $_.Name.EndsWith('.snupkg') } | ForEach-Object {
+          NuGetKeyVaultSignTool sign $_.Name `
+            --file-digest sha256 `
+            --timestamp-rfc3161 $timestampUrl `
+            --timestamp-digest sha256 `
+            --azure-key-vault-url '${{ inputs.codeSignKeyVault }}' `
+            --azure-key-vault-client-id '${{ inputs.codeSignClientId }}' `
+            --azure-key-vault-tenant-id '${{ inputs.codeSignTenantId }}' `
+            --azure-key-vault-client-secret '${{ inputs.codeSignClientSecret }}' `
+            --azure-key-vault-certificate '${{ inputs.codeSignCertificate }}'
+        }
+
+    - name: Upload Artifacts
+      if: ${{ inputs.artifact-name != '' }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ inputs.artifacts-path }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,20 +3,34 @@ name: PR
 on:
   pull_request:
     paths:
+    - '.github/workflows/**'
+    - '.github/actions/**'
     - 'Directory.*'
+    - 'global.json'
     - 'src/**'
     - 'E2E/**'
     - 'tests/**'
 
 jobs:
   build:
-    uses: avantipoint/workflow-templates/.github/workflows/msbuild-build.yml@master
-    with:
-      name: Build Mobile.BuildTools
-      solution-path: Mobile.BuildTools.sln
-      submodules: true
-      install-workload: 'maui macos maui-tizen'
-      vs-version: 17.12
+    runs-on: windows-latest
+    name: Build Mobile.BuildTools
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          submodules: true
+
+      - name: Build Mobile.BuildTools
+        uses: ./.github/actions/msbuild-build
+        with:
+          name: Build Mobile.BuildTools
+          solution-path: Mobile.BuildTools.sln
+          dotnet-version: '8.0.x'
+          dotnet-sdk-glob: '8.0.*'
+          install-workload: 'maui macos maui-tizen'
+          vs-version: '17.12'
 
   e2e:
     needs: [build]
@@ -31,7 +45,14 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: '8.0.x'
+
+      - name: Select .NET 8 SDK
+        shell: pwsh
+        run: |
+          $sdkVersion = dotnet --list-sdks | Where-Object { $_ -like '8.0.*' } | Select-Object -Last 1 | ForEach-Object { ($_ -split ' ')[0] }
+          if (-not $sdkVersion) { throw 'No .NET 8 SDK installed.' }
+          "DOTNET_SDK_VERSION=$sdkVersion" >> $env:GITHUB_ENV
 
       - name: Download NuGet Artifacts
         uses: actions/download-artifact@v4
@@ -40,7 +61,10 @@ jobs:
           path: Artifacts
 
       - name: Run Tests
-        run: dotnet test -c Release
+        shell: pwsh
+        run: |
+          $sdkDotnet = Join-Path $env:DOTNET_ROOT "sdk/$env:DOTNET_SDK_VERSION/dotnet.dll"
+          dotnet exec $sdkDotnet test -c Release
         working-directory: E2E/E2E.Tests
         env:
           AString: 'Hello World!'
@@ -52,4 +76,3 @@ jobs:
           AUri: 'https://mobilebuildtools.com'
           AStringArray: 'Foo;Bar;Baz'
           APlatformProperty: 'Should Not Exist'
-

--- a/global.json
+++ b/global.json
@@ -1,7 +1,5 @@
 {
   "sdk": {
-    "version": "9.0.300",
-    "rollForward": "latestPatch",
     "allowPrerelease": false
   },
   "msbuild-sdks": {

--- a/global.json
+++ b/global.json
@@ -1,5 +1,7 @@
 {
   "sdk": {
+    "version": "9.0.300",
+    "rollForward": "latestPatch",
     "allowPrerelease": false
   },
   "msbuild-sdks": {

--- a/src/Mobile.BuildTools.AppManifests/AndroidManifest.targets
+++ b/src/Mobile.BuildTools.AppManifests/AndroidManifest.targets
@@ -3,7 +3,7 @@
 
   <Target Name="_MBTGatherManifests"
           AfterTargets="_GetAndroidPackageName"
-          Condition=" $(_AndroidManifestAbs) != '' ">
+          Condition=" '$(_AndroidManifestAbs)' != '' ">
     <PropertyGroup>
       <_MBTUpdatedManifest>$(IntermediateOutputPath)Mobile.BuildTools\AndroidManifest.xml</_MBTUpdatedManifest>
       <_MBTSourceManifest>$(_AndroidManifestAbs)</_MBTSourceManifest>
@@ -11,12 +11,16 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <__MBTInputManifest Remove="@(__MBTInputManifest)" />
+      <__MBTOutputManifest Remove="@(__MBTOutputManifest)" />
       <__MBTInputManifest Include="$(_MBTSourceManifest)" />
       <__MBTOutputManifest Include="$(_MBTUpdatedManifest)" />
+      <FileWrites Include="$(_MBTUpdatedManifest)" />
     </ItemGroup>
 
     <Copy SourceFiles="@(__MBTInputManifest)"
-          DestinationFiles="@(__MBTOutputManifest)" />
+          DestinationFiles="@(__MBTOutputManifest)"
+          SkipUnchangedFiles="true" />
 
   </Target>
 

--- a/src/Mobile.BuildTools.AppManifests/AppleManifests.targets
+++ b/src/Mobile.BuildTools.AppManifests/AppleManifests.targets
@@ -57,9 +57,12 @@
           AfterTargets="_MBTGatherManifests"
           DependsOnTargets="HandleTokenizedInfoPlist;AutomaticBuildVersioning">
     <PropertyGroup Condition="$(BuildToolsEnableTemplateManifests) == 'True' Or $(BuildToolsEnableAutomaticVersioning) == 'True'">
+      <AppBundleManifest>$(_MBTUpdatedManifest)</AppBundleManifest>
       <_AppManifest>$(_MBTUpdatedManifest)</_AppManifest>
     </PropertyGroup>
     <ItemGroup Condition="$(BuildToolsEnableTemplateManifests) == 'True' Or $(BuildToolsEnableAutomaticVersioning) == 'True'">
+      <PartialAppManifest Remove="@(PartialAppManifest)" />
+      <PartialAppManifest Include="$(_MBTUpdatedManifest)" />
       <_PartialAppManifest Remove="@(_PartialAppManifest)" />
       <_PartialAppManifest Include="$(_MBTUpdatedManifest)" />
       <FileWrites Include="$(_MBTUpdatedManifest)" />

--- a/src/Mobile.BuildTools.AppManifests/AppleManifests.targets
+++ b/src/Mobile.BuildTools.AppManifests/AppleManifests.targets
@@ -61,10 +61,14 @@
       <_AppManifest>$(_MBTUpdatedManifest)</_AppManifest>
     </PropertyGroup>
     <ItemGroup Condition="$(BuildToolsEnableTemplateManifests) == 'True' Or $(BuildToolsEnableAutomaticVersioning) == 'True'">
-      <PartialAppManifest Remove="@(PartialAppManifest)" />
-      <PartialAppManifest Include="$(_MBTUpdatedManifest)" />
-      <_PartialAppManifest Remove="@(_PartialAppManifest)" />
-      <_PartialAppManifest Include="$(_MBTUpdatedManifest)" />
+      <_MBTSourcePartialAppManifest Remove="@(_MBTSourcePartialAppManifest)" />
+      <_MBTSourcePartialAppManifest Include="@(PartialAppManifest)" Condition="'%(PartialAppManifest.Identity)' == '$(_MBTSourcePlist)'" />
+      <_MBTSourceInternalPartialAppManifest Remove="@(_MBTSourceInternalPartialAppManifest)" />
+      <_MBTSourceInternalPartialAppManifest Include="@(_PartialAppManifest)" Condition="'%(_PartialAppManifest.Identity)' == '$(_MBTSourcePlist)'" />
+      <PartialAppManifest Remove="@(_MBTSourcePartialAppManifest)" />
+      <PartialAppManifest Include="$(_MBTUpdatedManifest)" Condition="'@(_MBTSourcePartialAppManifest)' != ''" />
+      <_PartialAppManifest Remove="@(_MBTSourceInternalPartialAppManifest)" />
+      <_PartialAppManifest Include="$(_MBTUpdatedManifest)" Condition="'@(_MBTSourceInternalPartialAppManifest)' != ''" />
       <FileWrites Include="$(_MBTUpdatedManifest)" />
     </ItemGroup>
   </Target>

--- a/src/Mobile.BuildTools.AppManifests/AppleManifests.targets
+++ b/src/Mobile.BuildTools.AppManifests/AppleManifests.targets
@@ -5,17 +5,21 @@
         AfterTargets="_DetectAppManifest"
         DependsOnTargets="MobileBuildToolsInit">
     <PropertyGroup>
-      <_MBTSourcePlist>$(AppBundleManifest)</_MBTSourcePlist>
+      <_MBTSourcePlist Condition=" '$(AppBundleManifest)' != '' ">$(AppBundleManifest)</_MBTSourcePlist>
+      <_MBTSourcePlist Condition=" '$(_MBTSourcePlist)' == '' ">$(_AppManifest)</_MBTSourcePlist>
       <_MBTUpdatedManifest>$(IntermediateOutputPath)Mobile.BuildTools\Info.plist</_MBTUpdatedManifest>
     </PropertyGroup>
 
     <ItemGroup>
-      <__MBTInputManifest Include="$(_AppManifest)" />
+      <__MBTInputManifest Remove="@(__MBTInputManifest)" />
+      <__MBTOutputManifest Remove="@(__MBTOutputManifest)" />
+      <__MBTInputManifest Include="$(_MBTSourcePlist)" />
       <__MBTOutputManifest Include="$(_MBTUpdatedManifest)" />
     </ItemGroup>
 
     <Copy SourceFiles="@(__MBTInputManifest)"
-          DestinationFiles="@(__MBTOutputManifest)" />
+          DestinationFiles="@(__MBTOutputManifest)"
+          SkipUnchangedFiles="true" />
   </Target>
 
   <!-- Process Info.plist -->
@@ -30,8 +34,8 @@
                           ManifestPath="$(_MBTUpdatedManifest)"
                           OutputManifestPath="$(_MBTUpdatedManifest)"
                           Condition="$(BuildToolsEnableTemplateManifests)">
-      <!-- <Output TaskParameter="ProcessedManifest"
-              PropertyName="_AppManifest" /> -->
+      <Output TaskParameter="ProcessedManifest"
+              ItemName="_MBTProcessedAppManifest" />
     </TemplateManifestTask>
   </Target>
 
@@ -52,7 +56,11 @@
   <Target Name="_MBTManifestPostProcess"
           AfterTargets="_MBTGatherManifests"
           DependsOnTargets="HandleTokenizedInfoPlist;AutomaticBuildVersioning">
+    <PropertyGroup Condition="$(BuildToolsEnableTemplateManifests) == 'True' Or $(BuildToolsEnableAutomaticVersioning) == 'True'">
+      <_AppManifest>$(_MBTUpdatedManifest)</_AppManifest>
+    </PropertyGroup>
     <ItemGroup Condition="$(BuildToolsEnableTemplateManifests) == 'True' Or $(BuildToolsEnableAutomaticVersioning) == 'True'">
+      <_PartialAppManifest Remove="@(_PartialAppManifest)" />
       <_PartialAppManifest Include="$(_MBTUpdatedManifest)" />
       <FileWrites Include="$(_MBTUpdatedManifest)" />
     </ItemGroup>

--- a/src/Mobile.BuildTools.AppManifests/Generators/Manifests/BaseTemplatedManifestGenerator.cs
+++ b/src/Mobile.BuildTools.AppManifests/Generators/Manifests/BaseTemplatedManifestGenerator.cs
@@ -7,7 +7,7 @@ namespace Mobile.BuildTools.Generators.Manifests
 {
     internal abstract class BaseTemplatedManifestGenerator : GeneratorBase<string>
     {
-        internal const string DefaultToken = @"\$\$";
+        internal const string DefaultToken = "$$";
 
         public BaseTemplatedManifestGenerator(IBuildConfiguration configuration)
             : base(configuration)

--- a/src/Mobile.BuildTools.AppManifests/Generators/Versioning/BuildVersionGeneratorBase.cs
+++ b/src/Mobile.BuildTools.AppManifests/Generators/Versioning/BuildVersionGeneratorBase.cs
@@ -52,6 +52,12 @@ namespace Mobile.BuildTools.Generators.Versioning
             LogManifestContents();
 
             Log.LogMessage("Processing Manifest");
+            var outputDirectory = Path.GetDirectoryName(ManifestOutputPath);
+            if (!string.IsNullOrWhiteSpace(outputDirectory))
+            {
+                Directory.CreateDirectory(outputDirectory);
+            }
+
             ProcessManifest(ManifestPath, ManifestOutputPath, BuildNumber);
 
             LogManifestContents();

--- a/src/Mobile.BuildTools.AppManifests/Mobile.BuildTools.AppManifests.csproj
+++ b/src/Mobile.BuildTools.AppManifests/Mobile.BuildTools.AppManifests.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Mobile.BuildTools.Core\Mobile.BuildTools.Core.csproj" />
-    <ProjectReference Include="..\Mobile.BuildTools.Reference\Mobile.BuildTools.Reference.csproj" PackFolder="build" SetTargetFramework="TargetFramework=net472" />
+    <ProjectReference Include="..\Mobile.BuildTools.Reference\Mobile.BuildTools.Reference.csproj" SetTargetFramework="TargetFramework=net472" />
     <ProjectReference Include="..\Mobile.BuildTools.XamarinSdk\Mobile.BuildTools.XamarinSdk.csproj" PackFolder="build" />
   </ItemGroup>
 

--- a/src/Mobile.BuildTools.AppManifests/Mobile.BuildTools.AppManifests.csproj
+++ b/src/Mobile.BuildTools.AppManifests/Mobile.BuildTools.AppManifests.csproj
@@ -29,8 +29,15 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Mobile.BuildTools.Core\Mobile.BuildTools.Core.csproj" />
-    <ProjectReference Include="..\Mobile.BuildTools.Reference\Mobile.BuildTools.Reference.csproj" PackFolder="build" />
+    <ProjectReference Include="..\Mobile.BuildTools.Reference\Mobile.BuildTools.Reference.csproj" PackFolder="build" SetTargetFramework="TargetFramework=net472" />
     <ProjectReference Include="..\Mobile.BuildTools.XamarinSdk\Mobile.BuildTools.XamarinSdk.csproj" PackFolder="build" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="$(OutputPath)Mobile.BuildTools.Core.dll;$(OutputPath)Mobile.BuildTools.Reference.dll;$(OutputPath)Microsoft.Bcl.AsyncInterfaces.dll;$(OutputPath)System.Buffers.dll;$(OutputPath)System.Memory.dll;$(OutputPath)System.Numerics.Vectors.dll;$(OutputPath)System.Runtime.CompilerServices.Unsafe.dll;$(OutputPath)System.Text.Encodings.Web.dll;$(OutputPath)System.Text.Json.dll;$(OutputPath)System.Threading.Tasks.Extensions.dll;$(OutputPath)System.ValueTuple.dll"
+          Pack="true"
+          PackagePath="build/%(Filename)%(Extension)"
+          Visible="false" />
   </ItemGroup>
 
   <Target Name="ExcludeTFM" BeforeTargets="_AddPackageManifest" AfterTargets="InferPackageContents">

--- a/src/Mobile.BuildTools.AppManifests/Mobile.BuildTools.AppManifests.targets
+++ b/src/Mobile.BuildTools.AppManifests/Mobile.BuildTools.AppManifests.targets
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project>
   <PropertyGroup>
-    <_MobileBuildToolsAppManifestTasksDll>$([System.IO.Path]::Combine('$(MSBuildThisFileDirectory)', 'Mobile.BuildTools.dll'))</_MobileBuildToolsAppManifestTasksDll>
+    <_MobileBuildToolsAppManifestTasksDll>$([System.IO.Path]::Combine('$(MSBuildThisFileDirectory)', 'Mobile.BuildTools.AppManifests.dll'))</_MobileBuildToolsAppManifestTasksDll>
   </PropertyGroup>
 
   <UsingTask TaskName="Mobile.BuildTools.Tasks.AutomaticBuildVersioningTask"
@@ -9,23 +9,14 @@
   <UsingTask TaskName="Mobile.BuildTools.Tasks.TemplateManifestTask"
              AssemblyFile="$(_MobileBuildToolsAppManifestTasksDll)"/>
 
-  <Choose>
-    <When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android' OR $(TargetFrameworkIdentifier) == 'MonoAndroid'">
-      <Import Project="AndroidManifest.targets" />
-    </When>
-    <When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' OR $(TargetFrameworkIdentifier) == 'Xamarin.iOS'">
-      <Import Project="AppleManifests.targets" />
-    </When>
-    <When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'macos' OR $(TargetFrameworkIdentifier) == 'Xamarin.Mac'">
-      <Import Project="AppleManifests.targets" />
-    </When>
-    <When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-      <Import Project="AppleManifests.targets" />
-    </When>
-    <When Condition="$(TargetFramework.Contains('windows10'))">
-
-    </When>
-  </Choose>
+  <Import Project="AndroidManifest.targets"
+          Condition=" $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android' OR '$(TargetFrameworkIdentifier)' == 'MonoAndroid' " />
+  <Import Project="AppleManifests.targets"
+          Condition=" $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' OR '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' " />
+  <Import Project="AppleManifests.targets"
+          Condition=" $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'macos' OR '$(TargetFrameworkIdentifier)' == 'Xamarin.Mac' " />
+  <Import Project="AppleManifests.targets"
+          Condition=" $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst' " />
 
   <Target Name="_TemplateManifestDebug"
           BeforeTargets="HandleTokenizedInfoPlist;HandleAndroidManifest"

--- a/src/Mobile.BuildTools.XamarinSdk/Mobile.BuildTools.XamarinSdk.csproj
+++ b/src/Mobile.BuildTools.XamarinSdk/Mobile.BuildTools.XamarinSdk.csproj
@@ -8,6 +8,7 @@
     <PackFolder>build</PackFolder>
     <IncludeSource>false</IncludeSource>
     <ImplicitUsings>false</ImplicitUsings>
+    <LangVersion>13.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Mobile.BuildTools.XamarinSdk/Mobile.BuildTools.XamarinSdk.csproj
+++ b/src/Mobile.BuildTools.XamarinSdk/Mobile.BuildTools.XamarinSdk.csproj
@@ -8,7 +8,7 @@
     <PackFolder>build</PackFolder>
     <IncludeSource>false</IncludeSource>
     <ImplicitUsings>false</ImplicitUsings>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Mobile.BuildTools.Tests/Fixtures/Generators/AppManifestGeneratorFixture.cs
+++ b/tests/Mobile.BuildTools.Tests/Fixtures/Generators/AppManifestGeneratorFixture.cs
@@ -1,9 +1,10 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Xml;
+using Mobile.BuildTools.Build;
 using Mobile.BuildTools.Generators;
 using Mobile.BuildTools.Generators.Manifests;
 using Mobile.BuildTools.Tests.Mocks;
@@ -18,6 +19,8 @@ namespace Mobile.BuildTools.Tests.Fixtures.Generators
         private const string TestPrefix = "XunitTest_";
         private static readonly string TemplateAndroidManifestPath = @"Templates/MockAndroidManifest.xml";
         private static readonly string TemplateAndroidManifestOutputPath = @"Generated/AndroidManifest.xml";
+        private static readonly string TemplateInfoPlistPath = @"Templates/MockInfo.plist";
+        private static readonly string TemplateInfoPlistOutputPath = @"Generated/Info.plist";
         private static readonly string TemplateManifestPath = @"Templates/MockManifestTemplate.json";
         private static readonly string TemplateManifestOutputPath = @"Generated/MockManifest.json";
 
@@ -97,21 +100,26 @@ namespace Mobile.BuildTools.Tests.Fixtures.Generators
             Assert.Equal("$TemplatedParameter$", json.TemplatedParameter);
         }
 
-        [Fact(Skip = "Dunno")]
+        [Fact]
         public void ProcessingDoesNotCorruptAndroidManifest()
         {
             var config = GetConfiguration();
-            var generator = CreateGenerator(config);
+            config.Platform = Platform.Android;
+            config.Configuration.Manifests.Token = "$$";
+            config.Configuration.Manifests.VariablePrefix = TestPrefix;
+            config.Configuration.Debug = true;
+            var generator = new TemplatedAndroidAppManifestGenerator(config)
+            {
+                ManifestInputPath = TemplateAndroidManifestPath,
+                ManifestOutputPath = TemplateAndroidManifestOutputPath
+            };
             var template = File.ReadAllText(TemplateAndroidManifestPath);
-            var guid = Guid.NewGuid().ToString();
+            var guid = Guid.NewGuid().ToString("N");
             Environment.SetEnvironmentVariable("XunitTest_AADClientId", guid);
 
             var matches = generator.GetMatches(template);
             var match = matches.Cast<Match>().First();
             Assert.Equal("$$AADClientId$$", match.Value);
-
-            generator.ManifestOutputPath = TemplateAndroidManifestOutputPath;
-            config.Configuration.Debug = true;
 
             var ex = Record.Exception(() => ((IGenerator)generator).Execute());
             Assert.Null(ex);
@@ -124,9 +132,46 @@ namespace Mobile.BuildTools.Tests.Fixtures.Generators
             });
 
             Assert.Null(ex);
-
             Assert.DoesNotContain("msal$$AADClientId$$", generatedTemplate);
             Assert.Contains($"msal{guid}", generatedTemplate);
+            Assert.Contains("package=\"com.avantipoint.awesomeapp\"", generatedTemplate);
+        }
+
+        [Fact]
+        public void ProcessingDoesNotCorruptInfoPlist()
+        {
+            var config = GetConfiguration();
+            config.Platform = Platform.iOS;
+            config.Configuration.Manifests.Token = "$$";
+            config.Configuration.Manifests.VariablePrefix = TestPrefix;
+            config.Configuration.Debug = true;
+            var generator = new TemplatedPlistGenerator(config)
+            {
+                ManifestInputPath = TemplateInfoPlistPath,
+                ManifestOutputPath = TemplateInfoPlistOutputPath
+            };
+            var template = File.ReadAllText(TemplateInfoPlistPath);
+            var guid = Guid.NewGuid().ToString("N");
+            Environment.SetEnvironmentVariable("XunitTest_AADClientId", guid);
+
+            var matches = generator.GetMatches(template);
+            var match = matches.Cast<Match>().First();
+            Assert.Equal("$$AADClientId$$", match.Value);
+
+            var ex = Record.Exception(() => ((IGenerator)generator).Execute());
+            Assert.Null(ex);
+
+            var generatedTemplate = File.ReadAllText(TemplateInfoPlistOutputPath);
+            ex = Record.Exception(() =>
+            {
+                var doc = new XmlDocument();
+                doc.LoadXml(generatedTemplate);
+            });
+
+            Assert.Null(ex);
+            Assert.DoesNotContain("msal$$AADClientId$$", generatedTemplate);
+            Assert.Contains($"msal{guid}", generatedTemplate);
+            Assert.Contains("com.avantipoint.awesomeapp", generatedTemplate);
         }
 
         private class TestManifest

--- a/tests/Mobile.BuildTools.Tests/Fixtures/Generators/AppManifestTargetsFixture.cs
+++ b/tests/Mobile.BuildTools.Tests/Fixtures/Generators/AppManifestTargetsFixture.cs
@@ -19,16 +19,39 @@ namespace Mobile.BuildTools.Tests.Fixtures.Generators
         }
 
         [Fact]
-        public void AppleTargetsCopyDetectedManifestAndReplacePartialManifestItem()
+        public void AppManifestTargetsUseTopLevelConditionalImports()
+        {
+            var document = LoadTargets("Mobile.BuildTools.AppManifests.targets");
+            var text = document.ToString();
+
+            Assert.DoesNotContain("<When", text);
+            Assert.Contains("<Import Project=\"AndroidManifest.targets\"", text);
+            Assert.Contains("<Import Project=\"AppleManifests.targets\"", text);
+            Assert.Contains("GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'", text);
+            Assert.Contains("GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'", text);
+            Assert.Contains("GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'", text);
+        }
+
+        [Fact]
+        public void AppManifestTargetsLoadTasksFromAppManifestsAssembly()
+        {
+            var text = LoadTargets("Mobile.BuildTools.AppManifests.targets").ToString();
+
+            Assert.Contains("Mobile.BuildTools.AppManifests.dll", text);
+            Assert.DoesNotContain("Mobile.BuildTools.dll", text);
+        }
+
+        [Fact]
+        public void AppleTargetsCopyDetectedManifestAndReplaceConsumedManifestItems()
         {
             var text = LoadTargets("AppleManifests.targets").ToString();
 
             Assert.Contains("<_MBTSourcePlist Condition=\" '$(AppBundleManifest)' != '' \">$(AppBundleManifest)</_MBTSourcePlist>", text);
             Assert.Contains("<_MBTSourcePlist Condition=\" '$(_MBTSourcePlist)' == '' \">$(_AppManifest)</_MBTSourcePlist>", text);
             Assert.Contains("<__MBTInputManifest Include=\"$(_MBTSourcePlist)\"", text);
-            Assert.Contains("<_AppManifest>$(_MBTUpdatedManifest)</_AppManifest>", text);
-            Assert.Contains("<_PartialAppManifest Remove=\"@(_PartialAppManifest)\"", text);
-            Assert.Contains("<_PartialAppManifest Include=\"$(_MBTUpdatedManifest)\"", text);
+            Assert.Contains("<AppBundleManifest>$(_MBTUpdatedManifest)</AppBundleManifest>", text);
+            Assert.Contains("<PartialAppManifest Remove=\"@(PartialAppManifest)\"", text);
+            Assert.Contains("<PartialAppManifest Include=\"$(_MBTUpdatedManifest)\"", text);
         }
 
         private static XDocument LoadTargets(string fileName)

--- a/tests/Mobile.BuildTools.Tests/Fixtures/Generators/AppManifestTargetsFixture.cs
+++ b/tests/Mobile.BuildTools.Tests/Fixtures/Generators/AppManifestTargetsFixture.cs
@@ -42,7 +42,7 @@ namespace Mobile.BuildTools.Tests.Fixtures.Generators
         }
 
         [Fact]
-        public void AppleTargetsCopyDetectedManifestAndReplaceConsumedManifestItems()
+        public void AppleTargetsCopyDetectedManifestAndPreserveUserPartialManifestItems()
         {
             var text = LoadTargets("AppleManifests.targets").ToString();
 
@@ -50,8 +50,14 @@ namespace Mobile.BuildTools.Tests.Fixtures.Generators
             Assert.Contains("<_MBTSourcePlist Condition=\" '$(_MBTSourcePlist)' == '' \">$(_AppManifest)</_MBTSourcePlist>", text);
             Assert.Contains("<__MBTInputManifest Include=\"$(_MBTSourcePlist)\"", text);
             Assert.Contains("<AppBundleManifest>$(_MBTUpdatedManifest)</AppBundleManifest>", text);
-            Assert.Contains("<PartialAppManifest Remove=\"@(PartialAppManifest)\"", text);
-            Assert.Contains("<PartialAppManifest Include=\"$(_MBTUpdatedManifest)\"", text);
+            Assert.DoesNotContain("<PartialAppManifest Remove=\"@(PartialAppManifest)\"", text);
+            Assert.DoesNotContain("<_PartialAppManifest Remove=\"@(_PartialAppManifest)\"", text);
+            Assert.Contains("<_MBTSourcePartialAppManifest Include=\"@(PartialAppManifest)\" Condition=\"'%(PartialAppManifest.Identity)' == '$(_MBTSourcePlist)'\"", text);
+            Assert.Contains("<_MBTSourceInternalPartialAppManifest Include=\"@(_PartialAppManifest)\" Condition=\"'%(_PartialAppManifest.Identity)' == '$(_MBTSourcePlist)'\"", text);
+            Assert.Contains("<PartialAppManifest Remove=\"@(_MBTSourcePartialAppManifest)\"", text);
+            Assert.Contains("<PartialAppManifest Include=\"$(_MBTUpdatedManifest)\" Condition=\"'@(_MBTSourcePartialAppManifest)' != ''\"", text);
+            Assert.Contains("<_PartialAppManifest Remove=\"@(_MBTSourceInternalPartialAppManifest)\"", text);
+            Assert.Contains("<_PartialAppManifest Include=\"$(_MBTUpdatedManifest)\" Condition=\"'@(_MBTSourceInternalPartialAppManifest)' != ''\"", text);
         }
 
         private static XDocument LoadTargets(string fileName)

--- a/tests/Mobile.BuildTools.Tests/Fixtures/Generators/AppManifestTargetsFixture.cs
+++ b/tests/Mobile.BuildTools.Tests/Fixtures/Generators/AppManifestTargetsFixture.cs
@@ -1,0 +1,49 @@
+using System;
+using System.IO;
+using System.Xml.Linq;
+using Xunit;
+
+namespace Mobile.BuildTools.Tests.Fixtures.Generators
+{
+    public class AppManifestTargetsFixture
+    {
+        [Fact]
+        public void AndroidTargetsRedirectBuildToProcessedManifest()
+        {
+            var text = LoadTargets("AndroidManifest.targets").ToString();
+
+            Assert.Contains("<_AndroidManifestAbs>$(_MBTUpdatedManifest)</_AndroidManifestAbs>", text);
+            Assert.Contains("ManifestPath=\"$(_MBTUpdatedManifest)\"", text);
+            Assert.Contains("OutputManifestPath=\"$(_MBTUpdatedManifest)\"", text);
+            Assert.Contains("<FileWrites Include=\"$(_MBTUpdatedManifest)\"", text);
+        }
+
+        [Fact]
+        public void AppleTargetsCopyDetectedManifestAndReplacePartialManifestItem()
+        {
+            var text = LoadTargets("AppleManifests.targets").ToString();
+
+            Assert.Contains("<_MBTSourcePlist Condition=\" '$(AppBundleManifest)' != '' \">$(AppBundleManifest)</_MBTSourcePlist>", text);
+            Assert.Contains("<_MBTSourcePlist Condition=\" '$(_MBTSourcePlist)' == '' \">$(_AppManifest)</_MBTSourcePlist>", text);
+            Assert.Contains("<__MBTInputManifest Include=\"$(_MBTSourcePlist)\"", text);
+            Assert.Contains("<_AppManifest>$(_MBTUpdatedManifest)</_AppManifest>", text);
+            Assert.Contains("<_PartialAppManifest Remove=\"@(_PartialAppManifest)\"", text);
+            Assert.Contains("<_PartialAppManifest Include=\"$(_MBTUpdatedManifest)\"", text);
+        }
+
+        private static XDocument LoadTargets(string fileName)
+        {
+            var path = Path.GetFullPath(Path.Combine(
+                AppContext.BaseDirectory,
+                "..",
+                "..",
+                "..",
+                "..",
+                "..",
+                "src",
+                "Mobile.BuildTools.AppManifests",
+                fileName));
+            return XDocument.Load(path);
+        }
+    }
+}

--- a/tests/Mobile.BuildTools.Tests/Fixtures/Generators/AutomaticBuildVersionGeneratorFixture.cs
+++ b/tests/Mobile.BuildTools.Tests/Fixtures/Generators/AutomaticBuildVersionGeneratorFixture.cs
@@ -1,0 +1,52 @@
+using System.IO;
+using System.Xml;
+using Mobile.BuildTools.Generators;
+using Mobile.BuildTools.Generators.Versioning;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Mobile.BuildTools.Tests.Fixtures.Generators
+{
+    public class AutomaticBuildVersionGeneratorFixture : FixtureBase
+    {
+        private const string TemplateAndroidManifestPath = @"Templates/MockAndroidManifest.xml";
+        private const string TemplateAndroidManifestOutputPath = @"Generated/VersionedAndroidManifest.xml";
+        private const string TemplateInfoPlistPath = @"Templates/MockInfo.plist";
+        private const string TemplateInfoPlistOutputPath = @"Generated/VersionedInfo.plist";
+
+        public AutomaticBuildVersionGeneratorFixture(ITestOutputHelper testOutputHelper)
+            : base(testOutputHelper)
+        {
+        }
+
+        [Fact]
+        public void AndroidVersioningDoesNotCorruptManifest()
+        {
+            var generator = new AndroidAutomaticBuildVersionGenerator(GetConfiguration(), TemplateAndroidManifestPath, TemplateAndroidManifestOutputPath);
+
+            ((IGenerator)generator).Execute();
+
+            var generated = File.ReadAllText(TemplateAndroidManifestOutputPath);
+            var doc = new XmlDocument();
+            doc.LoadXml(generated);
+            Assert.Contains($"android:versionCode=\"{generator.BuildNumber}\"", generated);
+            Assert.Contains($"android:versionName=\"1.0.{generator.BuildNumber}\"", generated);
+        }
+
+        [Fact]
+        public void iOSVersioningDoesNotCorruptPlist()
+        {
+            var generator = new iOSAutomaticBuildVersionGenerator(GetConfiguration(), TemplateInfoPlistPath, TemplateInfoPlistOutputPath);
+
+            ((IGenerator)generator).Execute();
+
+            var generated = File.ReadAllText(TemplateInfoPlistOutputPath);
+            var doc = new XmlDocument();
+            doc.LoadXml(generated);
+            Assert.Contains("<key>CFBundleVersion</key>", generated);
+            Assert.Contains($"<string>{generator.BuildNumber}</string>", generated);
+            Assert.Contains("<key>CFBundleShortVersionString</key>", generated);
+            Assert.Contains($"<string>1.0.{generator.BuildNumber}</string>", generated);
+        }
+    }
+}

--- a/tests/Mobile.BuildTools.Tests/Templates/MockInfo.plist
+++ b/tests/Mobile.BuildTools.Tests/Templates/MockInfo.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDisplayName</key>
+  <string>AwesomeApp</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.avantipoint.awesomeapp</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+  <key>CFBundleURLTypes</key>
+  <array>
+    <dict>
+      <key>CFBundleURLSchemes</key>
+      <array>
+        <string>msal$$AADClientId$$</string>
+      </array>
+    </dict>
+  </array>
+</dict>
+</plist>


### PR DESCRIPTION
Cleanup note: I removed stale bot inline comments and rewrote Dan-authored review notes here to read naturally. The remaining `### 💡 Codex Review` entry is a submitted bot review header, which is not editable/deletable by API, so it remains for traceability.